### PR TITLE
Corrected module name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Make sure the following python packages are installed
 pynag>=0.4.9
 Django>=1.3.0
-python-simplejson
+simplejson
 
 
 # nagios (or icinga)


### PR DESCRIPTION
Corrected module name, there is no `python-simplejson`:

```
Downloading/unpacking python-simplejson (from -r requirements.txt (line 4))
Could not find any downloads that satisfy the requirement python-simplejson (from -r requirements.txt (line 4))
No distributions at all found for python-simplejson (from -r requirements.txt (line 4))
```

The right name is `simplejson`.
