### PR TITLE
Remove date from top navigation clock

### DIFF
--- a/adagios/templates/snippets/top_navigation_bar.html
+++ b/adagios/templates/snippets/top_navigation_bar.html
@@ -69,7 +69,7 @@
                     </li>
                     -->
 
-                    <li class="dropdown"><a><i class="glyph-grey glyph-clock"></i> {% now "Y-m-d h:i T" %}</a></li>
+                    <li class="dropdown"><a><i class="glyph-grey glyph-clock"></i> {% now "h:i T" %}</a></li>
 
                     <li class="dropdown" id="user-drop-down">
                         <a class="dropdown-toggle"


### PR DESCRIPTION
It's a little too much to have the date as well as time in the top navigation. Introduced in issue #181 
