### PR TITLE
Replace site-package path in httpd config in distutils build

### DIFF
--- a/adagios.spec
+++ b/adagios.spec
@@ -38,12 +38,10 @@ sed -i "s/__version__=.*/__version__='$VERSION'/" adagios/__init__.py
 
 %build
 python setup.py build
-sed "s/python2.7/python%{python_version}/" -i adagios/apache/adagios.conf
 
 %install
 python setup.py install -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
 #chmod a+x %{buildroot}%{python_sitelib}/adagios/manage.py
-sed -i 's|/usr/lib/python2.7/site-packages|%{python_sitelib}|g' %{buildroot}%{python_sitelib}/adagios/apache/adagios.conf
 mkdir -p %{buildroot}%{_sysconfdir}/httpd/conf.d/
 install %{buildroot}%{python_sitelib}/adagios/apache/adagios.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/adagios.conf
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 import os
 
 from distutils.core import setup
+from distutils.command.build import build
+from distutils.sysconfig import get_python_lib
 from adagios import __version__
 
 app_name = 'adagios'
@@ -25,6 +27,28 @@ def get_filelist(path):
 template_files = get_filelist('adagios')
 data_files = map(lambda x: x.replace('adagios/','', 1), template_files)
 
+class adagios_build(build):
+    def run(self):
+        # Normal build:
+        build.run(self)
+
+        # Custom build steps:
+        adagios_conf_lines = []
+        site_packages_str = '/usr/lib/python2.7/site-packages'
+        # Python 2.4 compatibility
+        conf_r = open('build/lib/adagios/apache/adagios.conf', 'r')
+        try:
+            for line in conf_r.readlines():
+                adagios_conf_lines.append(line.replace(site_packages_str, get_python_lib()))
+        finally:
+            conf_r.close()
+        conf_w = open('build/lib/adagios/apache/adagios.conf', 'w')
+        try:
+            for line in adagios_conf_lines:
+                conf_w.write(line)
+        finally:
+            conf_w.close()
+
 setup(name=app_name,
     version=version,
     description='Web Based Nagios Configuration',
@@ -32,6 +56,8 @@ setup(name=app_name,
     author_email='palli@opensource.is',
     url='https://adagios.opensource.is/',
     packages=['adagios'],
-    package_data={'adagios': data_files }, requires=['django', "pynag"]
+    package_data={'adagios': data_files },
+    requires=['django', 'pynag'],
+    cmdclass=dict(build=adagios_build),
 
 )


### PR DESCRIPTION
I was installing from source and having to manually change adagios.conf seemed redundant work. It's a bit messier than the sed one-liner in the .spec file but I still think it's cleaner.

I removed two sed lines from the .spec. It looks like the one in the %build phase is replacing the line in the source itself after it gets built into the build/ directory so it doesn't seem to do anything. The second is basically what I implemented in setup.py.
