### PR TITLE
Update status_error.html - Fix typo

### DIFF
--- a/adagios/status/templates/status_error.html
+++ b/adagios/status/templates/status_error.html
@@ -40,7 +40,7 @@ service nagios reload
             Install instructions for debian-based systems:
             <pre>
 apt-get install check-mk-livestatus
-pynag config --append "broker_module=/usr/lib/check_mk/livestatus.o /var/lib/nagios3/rw/livestatus
+pynag config --append "broker_module=/usr/lib/check_mk/livestatus.o /var/lib/nagios3/rw/livestatus"
 service nagios3 reload
             </pre>
         {% endif %}


### PR DESCRIPTION
Fixed missing end quote in instructions to install livestatus. (Line 43)
