### PR TITLE
Moved WSGIProcessGroup within <location /adagios>

### DIFF
--- a/adagios/apache/adagios.conf
+++ b/adagios/apache/adagios.conf
@@ -1,12 +1,16 @@
 
+# Create the wsgi process group
 WSGISocketPrefix run/wsgi
 WSGIDaemonProcess adagios user=nagios group=nagios processes=1 threads=25
-WSGIProcessGroup adagios
 WSGIScriptAlias /adagios /usr/lib/python2.7/site-packages/adagios/wsgi.py
 
+# Run adagios under /adagios
 Alias /adagios/media /usr/lib/python2.7/site-packages/adagios/media
 
 <Location /adagios>
+   # Everything under /adagios runs in the above process group
+   WSGIProcessGroup adagios
+
    AuthName "Nagios Access"
    AuthType Basic
    AuthUserFile /etc/nagios/passwd


### PR DESCRIPTION
Without this patch we are setting the WSGIProcessGroup for the whole
webserver instead of just the adagios context. This change updates
it to only work within /adagios.
