### PR TITLE
add: graphite integration

### DIFF
--- a/adagios/settings.py
+++ b/adagios/settings.py
@@ -178,6 +178,27 @@ TOPMENU_ITEMS = [
     ('Nagios',    'nagios',        'misc.views.nagios',                     'glyph-list'),
 ]
 
+# Graphite #
+
+# to activate/deactivate Graphite
+GRAPHITE_ON = True
+
+# the url where to fetch data and images
+GRAPHITE_URL = "http://localhost:9091"
+
+# time ranges for generated graphs
+# the CSS identifier only needs to be unique here (it will be prefixed)
+GRAPHITE_PERIODS = [
+    # Displayed name, CSS identifier, Graphite period
+    ('4 hours',       'hours',        '-4h'),
+    ('One day',       'day',          '-1d'),
+    ('One week',      'week',         '-1w'),
+    ('One month',     'month',        '-1mon'),
+    ('One year',      'year',         '-1y'),
+    ]
+
+# default selected (active) tab, and the one rendered in General-preview
+GRAPHITE_DEFAULT_TAB = 'day'
 
 # Adagios specific configuration options. These are just the defaults,
 # Anything put in /etc/adagios.d/adagios.conf will overwrite this.

--- a/adagios/status/graphite.py
+++ b/adagios/status/graphite.py
@@ -1,0 +1,97 @@
+# Adagios is a web based Nagios configuration interface
+#
+# Copyright (C) 2014, Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def _get_graphite_url(base, host, service, metric, from_, title, width, height):
+    """ Constructs an URL for Graphite.
+    
+    Args:
+      - base (str): base URL for Graphite access
+      - host (str): hostname
+      - service (str): service, e.g. HTTP
+      - metric (str): metric, e.g. size, time
+      - from_ (str): Graphite time period
+      - title (str): title of the graphic
+      - width (int): width in pixels
+      - height (int): height in pixels
+
+    Returns: str
+    """
+    host = _compliant_name(host)
+    service = _compliant_name(service)
+    metric = _compliant_name(metric)
+
+    base = base.rstrip('/')
+
+    url = ('%(base)s/render/'
+           '?width=%(width)s'
+           '&height=%(height)s'
+           '&from=%(from_)s'
+           '&target=%(host)s.%(service)s.%(metric)s'
+           '&target=%(host)s.%(service)s.%(metric)s_warn'
+           '&target=%(host)s.%(service)s.%(metric)s_crit'
+           '&title=%(title)s')
+    
+    url %= dict(base=base, host=host, service=service, metric=metric,
+                from_=from_, width=width, height=height, title=title)
+    return url
+
+def _compliant_name(name):
+    """ Makes the necessary replacements for Graphite. """
+    if name == '_HOST_':
+        return '__HOST__'
+    for t in (' ', '/', '.'):
+        name = name.replace(t, '_')
+        print(t)
+    return name
+
+def get(base, host, service, metrics, units, width, height):
+    """ Returns a data structure containg URLs for Graphite.
+
+    The structure looks like:
+    [{'name': 'One day',
+      'css_id' : 'day',
+      'metrics': {'size': 'http://url-of-size-metric',
+                  'time': 'http://url-of-time-metric'}
+     },
+     {...}]
+    
+    Args:
+      - base (str): base URL for Graphite access
+      - host (str): hostname
+      - service (str): service, e.g. HTTP
+      - metric (str): metric, e.g. size, time
+      - units (list): a list of <name,css_id,unit>,
+        see adagios.settings.GRAPHITE_PERIODS
+      - width (int): width in pixels
+      - height (int): height in pixels
+
+    Returns: list
+    """
+    graphs = []
+    title = '%(host)s - %(service)s - %(metric)s'
+    
+    for name, css_id, unit in units:
+        m = {}
+        for metric in metrics:
+            titl = title % dict(host=host, service=service, metric=metric)
+            m[metric] = _get_graphite_url(base, host, service, metric,
+                                          unit, titl, width, height)
+        graph = dict(name=name, css_id=css_id, metrics=m)
+        graphs.append(graph)
+    
+    return graphs

--- a/adagios/status/templates/status_detail.html
+++ b/adagios/status/templates/status_detail.html
@@ -27,12 +27,15 @@
 
 {% block content %}
     <div class="row-fluid">
-    <div class="span9" id="maincontent_left_side">
+      <div class="span9" id="maincontent_left_side">
         <ul class="nav nav-tabs" id="objecttab">
             <li><a href="#general" data-toggle="tab">{% trans "General" %}</a></li>
             <li><a href="#information" data-toggle="tab">{% trans "Information" %}</a></li>
             <li><a href="#events" data-toggle="tab" id="history_link">{% trans "History" %}</a></li>
             <li><a href="#graphs" data-toggle="tab" id="graphs_link">{% trans "Graphs" %}</a></li>
+            {% if settings.GRAPHITE_ON %}
+              <li><a href="#graphite" data-toggle="tab" id="graphite_link">{% trans "Graphite" %}</a></li>
+            {% endif %}
             <li><a href="#custom_variables" data-toggle="tab">{% trans "Custom Variables" %}</a></li>
             <li><a href="#other" data-toggle="tab">{% trans "Debug" %}</a></li>
         </ul>
@@ -113,6 +116,9 @@
                                     <th>{% trans "min" %}</th>
                                     <th>{% trans "max" %}</th>
                                     <th>{% trans "pnp" %}</th>
+                                    {% if settings.GRAPHITE_ON %}
+                                      <th>{% trans "graphite" %}</th>
+                                    {% endif %}
                                 </tr>
                                 {% for i in perfdata %}
                                     <tr>
@@ -127,6 +133,9 @@
                                         <td>
                                             <a href="{% url pnp.views.pnp %}/image?host={{ host.name }}&source={{ i.i }}&srv={{ service_description }}" class="preview" title="{{ service_description }} {{ i.label }}"><i class="glyph glyph-charts"></i></a>
                                         </td>
+                                        {% if settings.GRAPHITE_ON %}
+                                          <td><a href="{{ graphite_default|hash:i.label }}" class="preview" title="{{ service_description }} {{ i.label }}"><i class="glyph glyph-charts"></i></a></td>
+                                        {% endif %}
                                     </tr>
                                 {% endfor %}
                             </table>
@@ -503,8 +512,31 @@
                     {% blocktrans with ot=my_object.object_type %}No Performance data is available for this {{ ot }}.{% endblocktrans %}
                 {% endif %}
         </div>
+        {% if settings.GRAPHITE_ON %}
+        <div class="tab-pane" id="graphite">
+          <div id="graphite" class="tabbable"> <!-- Only required for left/right tabs -->
+            <ul class="nav nav-pills" id="graphite_ul">
+              {% for graph in graphite %}
+                <li{% if graph.css_id == settings.GRAPHITE_DEFAULT_TAB %} class="active"{% endif %}><a href="#graphite_{{ graph.css_id }}" id="graphite_{{ graph.css_id }}_link" data-toggle="tab">{% trans graph.name %}</a></li>
+              {% endfor %}
+            </ul>
+
+            <div class="tab-content" id="graphs_content">
+              {% for graph in graphite %}
+                <div class="tab-pane{% if graph.css_id == settings.GRAPHITE_DEFAULT_TAB %} active{% endif %}" id="graphite_{{ graph.css_id }}">
+                  {% for k,v in graph.metrics.items %}
+                    <img src="{{ v }}" />
+                    <br /><br />
+                  {% endfor %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
         </div>
-    </div>
+        {% endif %}
+        
+        </div>
+      </div>
 
     <div class="span3 visible-desktop" id="maincontent_right_side">
     {% if host.services_with_info %}

--- a/adagios/status/templatetags/adagiostags.py
+++ b/adagios/status/templatetags/adagiostags.py
@@ -37,3 +37,9 @@ def duration(value):
     """
     zero = datetime.min
     return timesince(zero, zero + timedelta(0, value))
+
+@register.filter("hash")
+def hash(h, key):
+    return h[key]
+
+


### PR DESCRIPTION
few things to note:
- different units/periods for Graphite can be loaded
- the urls are constructed in status/graphite.py
- graphite can be set up anywhere (outside of adagios), its url is a parameter

Discussion: now that we have Graphite, best way to activate/deactivate Pnp?
