### PR TITLE
bug fix: when no or only one backend is defined, don't display list

### DIFF
--- a/adagios/templates/snippets/top_navigation_bar.html
+++ b/adagios/templates/snippets/top_navigation_bar.html
@@ -89,6 +89,7 @@
                             <li><a href="#" onclick="adagios.misc.logout(); return false;">{% trans "Sign Out" %}</a></li>
                         </ul>
                     </li>
+                    {% if backends|length >= 2 %}
                     <li class="dropdown">
                       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                         <i class="glyph-tags glyph-grey"></i>
@@ -104,6 +105,7 @@
                         {% endfor %}
                       </ul>
                     </li>
+                    {% endif %}
                     <li class="dropdown">
                         <a class="dropdown-toggle"
                            data-toggle="dropdown"


### PR DESCRIPTION
There is no need to activate/deactivate backends if there's no backend,
let's not confuse the users with an useless menu :)
