### PR TITLE
Added conflict for Django older than 1.4.0

### DIFF
--- a/adagios.spec
+++ b/adagios.spec
@@ -29,6 +29,8 @@ Requires: python-simplejson
 
 %if 0%{?rhel} >= 6 || 0%{?fedora} >= 20
 Requires: python-django15
+# Force django upgrade
+Conflicts: Django < 1.4.0
 %else
 # Fedora 19, python-django is 1.5
 Requires: python-django


### PR DESCRIPTION
Centos/RHEL shipped with Django-1.3 originally, those unfortunate souls
that installed before the Django14 need to remove Django and install
Django14.

Done via:
  yum remove Django
  yum install Django14

Another option could be to insist on upgrading to python-django15. Which
might be intrusive for more users. They will have to remove Django14 even
though it works fine.

But it will make it easier to obsolete django 1.4 in the future. Done via
Conflicts: Django < 1.5.0
