### PR TITLE
Fix wrong content type sent with ajax calls.

### DIFF
--- a/adagios/rest/templates/javascript.html
+++ b/adagios/rest/templates/javascript.html
@@ -59,7 +59,7 @@ adagios.rest.{{ module_name }}.{{ i }} = function(parameters) {
         async: true,
         success: function(data) { console.debug("call to adagios.rest.{{ module_name }}.{{ i }}() was a success"); },
         fail: function(data) { console.error("error while calling call to adagios.rest.{{ module_name }}.{{ i }}"); console.error(data); },
-        contentType: "application/json",
+        contentType: "application/x-www-form-urlencoded; charset=UTF-8",
         dataType: 'json'
     });
 

--- a/adagios/status/templates/base_status.html
+++ b/adagios/status/templates/base_status.html
@@ -620,7 +620,7 @@
                 error: function(data) {
                   adagios.misc.error(gettext("Error sending mail"), "mail_sent");
                 },
-                contentType: "application/json"
+                contentType: "application/x-www-form-urlencoded; charset=UTF-8",
             });
 
         };

--- a/adagios/status/tests.py
+++ b/adagios/status/tests.py
@@ -29,6 +29,7 @@ import adagios.status.utils
 import adagios.status.graphite
 import adagios.settings
 import adagios.utils
+import simplejson as json
 
 
 class LiveStatusTestCase(unittest.TestCase):
@@ -127,6 +128,18 @@ class LiveStatusTestCase(unittest.TestCase):
         response = c.post('/rest/status/json/submit_check_result', data=data)
         self.assertEqual(200, response.status_code)
 
+    def test_rest_top_alert_producers(self):
+        """ Test adagios.rest.status.top_alert_producers
+        """
+        c = Client()
+        data = {}
+        data['limit'] = '1'
+        response = c.post('/rest/status/json/top_alert_producers', data=data)
+        self.assertEqual(200, response.status_code)
+
+        json_reply = json.loads(response.content)
+        self.assertFalse(len(json_reply) > 1, "Too many objects returned" \
+                         " limit is 1, json:\n" + str(json_reply))
 
 class Graphite(unittest.TestCase):
     def test__get_graphite_url(self):


### PR DESCRIPTION
Most of the calls to the ReST api were broken in django 1.5 as a result
of sending application/json in the request on POSTs.

Reference:
https://docs.djangoproject.com/en/dev/releases/1.5/#non-form-data-in-http-requests

Added a unit test to check returns of top_alert_producers although that
was not triggered during this specific issue.

Fixes #422
