### PR TITLE
Objectbrowser - remove leftover breadcrumbs

### DIFF
--- a/adagios/objectbrowser/templates/base_objectbrowser.html
+++ b/adagios/objectbrowser/templates/base_objectbrowser.html
@@ -13,17 +13,6 @@
                     <div class="block" id="page_header">
                         <!-- block page_header starts -->
                         {% block page_header %}
-                            <ul class="breadcrumb">
-                                <li>
-                                    <a href="{% url "home" %}">{% trans "Home" %}</a> <span class="divider">/</span>
-                                </li>
-                                <li>
-                                    {% block nav1 %}
-                                        <a href="{% url "objectbrowser" %}">objectbrowser</a>
-                                    {% endblock %}
-                                    <span class="divider">/</span>
-                                </li>
-                            </ul>
                             <h2>
                                 <i class="icon-th-large"></i> <small>{% block smallheader %}block=smallheader{% endblock%} </small> {% block largeheader %}block=largeheader{% endblock %}
                             </h2>


### PR DESCRIPTION
It seems that previously when breadcrumbs where removed,
the edit_object view was forgotten (maybe because edit_object
was never migrated to the new template).

Current breadcrumb is kind of pointless anyway, since it is only a few
pixels from the "home" and "configure" buttons, and we dont have an
ability to link specifically to all object types (like servicegroups)

Fixes #414
