### PR TITLE
Disable reschedule button in status_detail if active checks are not enabled

### DIFF
--- a/adagios/status/templates/status_detail.html
+++ b/adagios/status/templates/status_detail.html
@@ -687,6 +687,12 @@
                 $('#acknowledge_text').html('Is acknowledged');
             {% endif %}
 
+             // Disable recheck button if active checks are not enabled
+             {% if my_object.active_checks_enabled == 0 %}
+                 $('#reschedule_button').attr('disabled','disabled');
+                 $('#rescheduled_text').html('Active checks disabled');
+             {% endif %}
+
             // Fetch the effective check command for this object
             var parameters = {};
             parameters['host_name'] = "{{ host_name }}";


### PR DESCRIPTION
We are using check_mk and have a lot of services with passive checks.  Noticed if we go into status_detail for a passive check service the reschedule button is active.  Clicking on it yields a warning/error about needing to disable active checks. This change disables the button if the host/service does not have active checks enabled.
