### PR TITLE
setup.py: update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(name=app_name,
     packages=['adagios'],
     package_data={'adagios': data_files},
     data_files=[('/etc/adagios/', ['adagios/etc/adagios/adagios.conf'])],
-    install_requires=['django', 'pynag'],
+    install_requires=['django>=1.4,<1.7', 'pynag'],
     cmdclass=dict(build=adagios_build),
 
 )


### PR DESCRIPTION
Adagios 1.6.1 doesn't work Django 1.7.x so we require version between 1.4.x and 1.6.x.
