### PR TITLE
Make unhandled hosts/services configurable

### DIFF
--- a/adagios/settings.py
+++ b/adagios/settings.py
@@ -179,6 +179,26 @@ TOPMENU_ITEMS = [
 
 ]
 
+# This mapping shows how we define a service as 'unhandled'
+UNHANDLED_SERVICES = {
+    'state__isnot': 0,
+    'acknowledged': 0,
+    'scheduled_downtime_depth': 0,
+    'host_state': 0,
+    'host_scheduled_downtime_depth': 0,
+    'host_acknowledged': 0,
+}
+
+
+# This mapping shows how we define a host as 'unhandled'
+UNHANDLED_HOSTS = {
+    'state': 1,
+    'acknowledged': 0,
+    'scheduled_downtime_depth': 0
+}
+
+
+
 # Graphite #
 
 # the url where to fetch data and images

--- a/adagios/status/utils.py
+++ b/adagios/status/utils.py
@@ -70,25 +70,6 @@ _DEFAULT_HOST_COLUMNS = [
 ]
 
 
-# This mapping shows how we define a service as 'unhandled'
-_FILTER_UNHANDLED_SERVICES = {
-    'state__isnot': 0,
-    'acknowledged': 0,
-    'scheduled_downtime_depth': 0,
-    'host_state': 0,
-    'host_scheduled_downtime_depth': 0,
-    'host_acknowledged': 0,
-}
-
-
-# This mapping shows how we define a host as 'unhandled'
-_FILTER_UNHANDLED_HOSTS = {
-    'state': 1,
-    'acknowledged': 0,
-    'scheduled_downtime_depth': 0
-}
-
-
 # Use these fields when making a generic search for hosts
 _GENERIC_SEARCH_FIELDS_HOST = [
     'name__contains', 'address__contains', 'plugin_output__contains', 'alias__contains']
@@ -233,7 +214,7 @@ def _process_querystring_for_host(*args, **kwargs):
     # If the unhandled keyword appears in our querystring, we automatically add
     # some search filters:
     if kwargs.pop(_UNHANDLED, False):
-        kwargs.update(_FILTER_UNHANDLED_HOSTS)
+        kwargs.update(adagios.settings.UNHANDLED_HOSTS)
 
     # If _IN_SCHEDULED_DOWNTIME querystring is applied, we have to transmute it
     # To a different query that livestatus understands:
@@ -323,7 +304,7 @@ def _process_querystring_for_service(*args, **kwargs):
     # If the unhandled keyword appears in our querystring, we automatically add
     # some search filters:
     if kwargs.pop(_UNHANDLED, False):
-        kwargs.update(_FILTER_UNHANDLED_SERVICES)
+        kwargs.update(adagios.settings.UNHANDLED_SERVICES)
 
     # If _IN_SCHEDULED_DOWNTIME querystring is applied, we have to transmute it
     # To a different query that livestatus understands:


### PR DESCRIPTION
This patch moves the definition of unhandled/open problems
into settings.py

As a side effect of this, definition of unhandled can be overwritten
in adagios.conf by adding these to the config file:

UNHANDLED_SERVICES = {
    'state__isnot': 0,
    'acknowledged': 0,
    'scheduled_downtime_depth': 0,
    'host_state': 0,
    'host_scheduled_downtime_depth': 0,
    'host_acknowledged': 0,
}
UNHANDLED_HOSTS = {
    'state': 1,
    'acknowledged': 0,
    'scheduled_downtime_depth': 0
}

This partially fixes #471 although we are not providing the ability
yet to configure this from the settings web interface.
