### PR TITLE
Serverside includes for emails

### DIFF
--- a/adagios/misc/templates/snippets/misc_mail_objectlist.html
+++ b/adagios/misc/templates/snippets/misc_mail_objectlist.html
@@ -1,6 +1,15 @@
 <!-- snippet misc_mail_servicelist.html ends -->
 {% load adagiostags %}
 {% load i18n %}
+
+<!-- begin serverside includes -->
+{% for ssi_header in ssi_headers %}
+    <!-- including content from {{ ssi_header }} -->
+    {% ssi ssi_header parsed %}
+    <!-- end of file {{ ssi_header }} -->
+{% endfor %}
+<!-- end of serverside includes -->
+
 {% if please_skipt_this %}
     <style>
         /* we use http://beaker.mailchimp.com/inline-css Dont remove this style */
@@ -46,4 +55,11 @@ The following {{ services|length }} items were {% if acknowledged_or_not %}{% el
 </table>
 
 total {{ services|length }} objects.
+<!-- begin serverside includes -->
+{% for ssi_footer in ssi_footers %}
+    <!-- including content from {{ ssi_footer }} -->
+    {% ssi ssi_footer parsed %}
+    <!-- end of file {{ ssi_footer }} -->
+{% endfor %}
+<!-- end of serverside includes -->
 <!-- snippet misc_mail_servicelist.html ends -->

--- a/adagios/templates/base.html
+++ b/adagios/templates/base.html
@@ -41,7 +41,7 @@
 
 <body>
 
-<!-- begin serverside includes -->
+<!-- begin serverside includes from common-header.ssi and {{ urlname }}-header.ssi -->
 {% for ssi_header in ssi_headers %}
     <!-- including content from {{ ssi_header }} -->
     {% ssi ssi_header parsed %}
@@ -224,7 +224,7 @@
 {% endblock %}
 <!-- block footer ends -->
 
-<!-- begin serverside includes -->
+<!-- begin serverside includes for common-footer.ssi and {{ urlname }}-footer.ssi -->
 {% for ssi_footer in ssi_footers %}
     <!-- including content from {{ ssi_footer }} -->
     {% ssi ssi_footer parsed %}


### PR DESCRIPTION
This patch adds the ability to inject serverside includes in emails
Additionally improves the html in base.html so that it is always clear
what is the name of ssi relevant for current SSI.

This pull request fixes #445
