### PR TITLE
New endpoint: /objectbrowser/import

### DIFF
--- a/adagios/objectbrowser/templates/import_objects.html
+++ b/adagios/objectbrowser/templates/import_objects.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Import objects" %}{% endblock %}
+{% block smallheader %}{% trans "Import" %}{% endblock %}
+{% block largeheader %}{% trans "Objects" %}{% endblock %}
+{% block nav1 %}{% trans "Import Objects" %}{% endblock %}
+{% block toolbar %}{% endblock %}
+{% block footer %}
+    <script>
+        $('table#many').dataTable( {
+                    "sPaginationType": "bootstrap",
+                    "sScrollY": "260px",
+                    "bAutoWidth": false,
+                    "bScrollCollapse": true,
+                    "bPaginate": false,
+                    "sDom": 'rtp'
+                }
+        );
+    </script>
+{% endblock %}
+
+{%  block content %}
+
+    <div class="alert alert-info">
+        <p>This form is meant for bulk importing objects from a comma seperated file or or string.</p>
+        <p>Only use this if you know what you are doing.</p>
+    </div>
+
+    {% if saved_objects %}
+        <div class="alert alert-success">{{ saved_objects|length }} objects saved.</div>
+        <table class="table">
+            <tr>
+                <th>Object Type</th>
+                <th>Short Name</th>
+                <th>File Name</th>
+            </tr>
+            {% for i in saved_objects %}
+                <tr>
+                    <td>{{ i.object_type }}</td>
+                    <td>
+                        <a href="{% url "objectbrowser.views.edit_object" %}?object_type={{ i.object_type }}&shortname={{ i.shortname }}">
+                            {{ i.shortname }}
+                        </a>
+                    </td>
+                    <td>{{ i.filename }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <form action="#" method="post" class="form-horizontal">{% csrf_token %}
+            {% for i in duplicate_objects %}
+                <div class="alert alert-warning">{{ i.object_type }} '{{ i.shortname }}' already exists in config. Not overwriting.</div>
+            {% endfor %}
+            {% if unique_objects %}
+                Preview of objects to be saved:
+                <pre>
+                {% for i in unique_objects %}{{ ''|linebreaks }}# {{ i.filename }}{{ i|linebreaks }}{% endfor %}
+                </pre>
+                <div class=hide>{% include "bootstrap_fields.html" with fields=form %}</div>
+                <button class="btn btn-primary" name=save-button type="submit">Save</button>
+
+            {% else %}
+                {% include "bootstrap_fields.html" with fields=form %}
+                <div class="form-actions">
+                    <button class="btn btn-primary" name=preview-button type="submit">Preview</button>
+                </div>
+            {% endif%}
+
+        </form>
+    {% endif %}
+{%  endblock %}
+

--- a/adagios/objectbrowser/urls.py
+++ b/adagios/objectbrowser/urls.py
@@ -27,7 +27,7 @@ urlpatterns = patterns('adagios',
 
 
     url(r'^/edit/(?P<object_id>.+?)?$', 'objectbrowser.views.edit_object', name="edit_object"),
-
+    url(r'^/import/?$', 'objectbrowser.views.import_objects'),
     url(r'^/edit/?$', 'objectbrowser.views.edit_object'),
     url(r'^/copy_and_edit/(?P<object_id>.+?)?$', 'objectbrowser.views.copy_and_edit_object'),
 

--- a/adagios/objectbrowser/views.py
+++ b/adagios/objectbrowser/views.py
@@ -924,3 +924,15 @@ def copy_and_edit_object(request, object_id):
     return HttpResponseRedirect(reverse('edit_object', kwargs={'object_id': o.get_id()}))
 
 
+@adagios_decorator
+def import_objects(request):
+    if request.method == 'POST':
+            form = ImportObjectsForm(data=request.POST)
+            if form.is_valid():
+                duplicate_objects = form.get_duplicate_pynag_objects()
+                unique_objects = form.get_unique_pynag_objects()
+                if 'save-button' in request.POST:
+                    saved_objects = form.save()
+    else:
+        form = ImportObjectsForm(initial=request.GET)
+    return render_to_response('import_objects.html', locals(), context_instance=RequestContext(request))

--- a/adagios/templates/snippets/top_navigation_bar.html
+++ b/adagios/templates/snippets/top_navigation_bar.html
@@ -128,6 +128,7 @@
                             <li class="divider"></li>
                             <li><a href="{%  url 'objectbrowser.views.show_plugins' %}">{% trans "Missing Plugins" %}</a></li>
                             <li><a href="{%  url 'objectbrowser.views.edit_nagios_cfg' %}">{% trans "Edit nagios.cfg" %}</a></li>
+                            <li><a href="{%  url 'objectbrowser.views.import_objects' %}">{% trans "Import Objects" %}</a></li>
                             <li><a href="{%  url 'misc.views.nagios_service' %}">{% trans "Nagios Service" %}</a></li>
                             <li><a href="{%  url 'misc.views.gitlog' %}">{% trans "Object History" %}</a></li>
                             <li><a href="{%  url 'misc.views.settings' %}">{% trans "Settings" %}</a></li>


### PR DESCRIPTION
Allows importing of objects from a CSV style input
- New view /objectbrowser/import
- Added link to "top-right-cogwheel" called "import objects"
- Primitive duplication support (i.e. refuses to import objects already in config)
- Allows preview of what will be saved

Fixes #382
