### PR TITLE
Fix delete of saved searches with spaces

### DIFF
--- a/adagios/media/js/adagios_status.js
+++ b/adagios/media/js/adagios_status.js
@@ -8,7 +8,7 @@ adagios.bi = adagios.bi || {};
 adagios.misc.__notification_id_counter = 0;
 
 // When saved search items are added to the left sidebar, this is what they look like:
-adagios.misc._saved_search_element = '<li><div><a  href="URL">NAME</a><button type="button" class="pull-right close" onclick=adagios.misc.delete_saved_search("NAME");>&times;</button></div></li>';
+adagios.misc._saved_search_element = '<li><div><a  href="URL">NAME</a><button type="button" class="pull-right close" onclick=\'adagios.misc.delete_saved_search("NAME");\'>&times;</button></div></li>';
 
 
 $(document).ready(function() {


### PR DESCRIPTION
Without this patch, saved searches break when there is a space in the search name.
