### PR TITLE
service_detail page javascript errors on spaces

### DIFF
--- a/adagios/media/js/adagios_status.js
+++ b/adagios/media/js/adagios_status.js
@@ -1035,7 +1035,8 @@ adagios.misc.populate_search_with_querystring_fields = function(dom) {
             continue;
         }
         // If we find a checkbox with same name and value, make sure it is checked:
-        check_box_selector = 'input[name=' + key + '][value=' + value + ']';
+        check_box_selector = 'input[name="KEY"][value="VALUE"]';
+        check_box_selector = check_box_selector.replace('KEY', key).replace('VALUE', value);
         dom.find(check_box_selector).prop('checked', true);
     }
 };


### PR DESCRIPTION
This patch fixes a bug in adagios.misc.populate_search_with_querystring_fields() javascript code
that would generate an incorrect jquery selector if you were on a service detail for a serice
with space in the description.

This would cause javascripts to fail on that page, including 'other services on this host' breaking.
