### PR TITLE
Fix timed reload on service pages

### DIFF
--- a/adagios/status/templates/status_index.html
+++ b/adagios/status/templates/status_index.html
@@ -261,7 +261,7 @@
             // Get latest adagios version:
             $('#latest_version').adagios_version();
 
-            // Set a reload in 30 seconds
+            // Set a reload in X seconds
             adagios.misc.timed_reload({{ user_data.refresh_rate }});
         });
 

--- a/adagios/status/templates/status_problems.html
+++ b/adagios/status/templates/status_problems.html
@@ -36,25 +36,7 @@
     {{ block.super }}
 
     <script>
-        function timedRefresh(timeoutPeriod) {
-            var interval = setInterval(refreshPage, timeoutPeriod);
-        }
-
-        function refreshPage() {
-            var checked_boxes = $( ".selectable :checked" );
-            var shown_modals = $("div .modal.in");
-            if (checked_boxes.length + shown_modals.length == 0) {
-                console.log("Refreshing page...");
-                location.reload();
-            }
-            else {
-                console.log("Canceled auto-refresh of page because input boxes or modals have been edited");
-                clearInterval(1);
-            }
-        }
-
-        $(document).ready(function() {
-            timedRefresh(30000);
-        });
+        // Set a reload in X seconds
+        adagios.misc.timed_reload({{ user_data.refresh_rate }});
     </script>
 {% endblock %}

--- a/adagios/status/templates/status_services.html
+++ b/adagios/status/templates/status_services.html
@@ -22,25 +22,7 @@
     {{ block.super }}
 
     <script>
-        function timedRefresh(timeoutPeriod) {
-            var interval = setInterval(refreshPage, timeoutPeriod);
-        }
-
-        function refreshPage() {
-            var checked_boxes = $( ".selectable :checked" );
-            var shown_modals = $("div .modal.in");
-            if (checked_boxes.length + shown_modals.length == 0) {
-                console.log("Refreshing page...");
-                location.reload(true);
-            }
-            else {
-                console.log("Canceled auto-refresh of page because input boxes or modals have been edited");
-                clearInterval(1);
-            }
-        }
-
-        $(document).ready(function() {
-            timedRefresh(30000);
-        });
+        // Set a reload in X seconds
+        adagios.misc.timed_reload({{ user_data.refresh_rate }});
     </script>
 {% endblock %}


### PR DESCRIPTION
Timed refresh on service pages was using obsolete code, changed
it so that now we are using the same reload behavior as status overview does.

Fixes #438
