### PR TITLE
Handle IOError exception when object is saved

### DIFF
--- a/adagios/objectbrowser/forms.py
+++ b/adagios/objectbrowser/forms.py
@@ -263,7 +263,18 @@ class PynagForm(AdagiosForm):
             self.fields[k] = self.get_pynagField(k, css_tag="defined")
             self.fields[k].value = value
         self.pynag_object.save()
-        adagios.misc.rest.add_notification(message=_("Object successfully saved"), level="success", notification_type="show_once")
+
+        try:
+            self.pynag_object.save()
+            adagios.misc.rest.add_notification(message=_(
+                "Object successfully saved"),
+                level="success",
+                notification_type="show_once")
+        except IOError:
+            adagios.misc.rest.add_notification(message=_(
+                "Object cannot be saved : Permission denied on file system"),
+                level="danger",
+                notification_type="show_once")
 
     def __init__(self, pynag_object, *args, **kwargs):
         self.pynag_object = p = pynag_object


### PR DESCRIPTION
Hi,

This patch add a notification (level=danger) if an IOError exception (permission denied) occur when you save an object. Actually, Adagios return an error page and don't handle the real exception. See #529 

I hope PEP8 syntax is not a problem ;)