### PR TITLE
 Handle IOError exception when object is saved

### DIFF
--- a/adagios/objectbrowser/forms.py
+++ b/adagios/objectbrowser/forms.py
@@ -263,7 +263,18 @@ class PynagForm(AdagiosForm):
             self.fields[k] = self.get_pynagField(k, css_tag="defined")
             self.fields[k].value = value
         self.pynag_object.save()
-        adagios.misc.rest.add_notification(message=_("Object successfully saved"), level="success", notification_type="show_once")
+
+        try:
+            self.pynag_object.save()
+            adagios.misc.rest.add_notification(message=_(
+                "Object successfully saved"),
+                level="success",
+                notification_type="show_once")
+        except IOError:
+            adagios.misc.rest.add_notification(message=_(
+                "Object cannot be saved : Permission denied on file system"),
+                level="danger",
+                notification_type="show_once")
 
     def __init__(self, pynag_object, *args, **kwargs):
         self.pynag_object = p = pynag_object

--- a/adagios/objectbrowser/forms.py
+++ b/adagios/objectbrowser/forms.py
@@ -262,7 +262,6 @@ class PynagForm(AdagiosForm):
             # Additionally, update the field for the return form
             self.fields[k] = self.get_pynagField(k, css_tag="defined")
             self.fields[k].value = value
-        self.pynag_object.save()
 
         try:
             self.pynag_object.save()

--- a/adagios/status/views.py
+++ b/adagios/status/views.py
@@ -193,7 +193,7 @@ def snippets_log(request):
     if service_description == "_HOST_":
         service_description = None
 
-    log = utils.get_state_history(host_name=host_name, service_description=service_description)
+    log = utils.get_state_history(request, host_name=host_name, service_description=service_description)
 
     # If hostgroup_name was specified, lets get all log entries that belong to that hostgroup
     if host_name and service_description:


### PR DESCRIPTION
Hi,

This patch add a notification (level=danger) if an IOError exception (permission denied) occur when you save an object. Actually, Adagios return an error page and don't handle the real exception. See #529 

I hope PEP8 syntax is not a problem ;)
