### PR TITLE
Updated rest.py reschedule method to use an integer time instead of decimal

### DIFF
--- a/adagios/status/rest.py
+++ b/adagios/status/rest.py
@@ -264,12 +264,12 @@ def reschedule_many(request, hostlist, servicelist, check_time=None, **kwargs):
     #WaitCondition = "last_check > %s" % int(time.time()- 1)
     for i in hostlist.split(';'):
         if not i: continue
-        reschedule(request, host_name=i, service_description=None, check_time=check_time)
+        reschedule(request, host_name=i, service_description=None, check_time=int(check_time))
         #task.add(wait, 'hosts', i, WaitCondition)
     for i in servicelist.split(';'):
         if not i: continue
         host_name,service_description = i.split(',')
-        reschedule(request, host_name=host_name, service_description=service_description, check_time=check_time)
+        reschedule(request, host_name=host_name, service_description=service_description, check_time=int(check_time))
         #WaitObject = "{h};{s}".format(h=host_name, s=service_description)
         #task.add(wait, 'services', WaitObject, WaitCondition)
     return {'message': _("command sent successfully")}


### PR DESCRIPTION
In Naemon 0.9.1 the service recheck option fails without error.  It says the command is sent successfully, but naemon.log shows the following:
Parse error: Invalid characters (.78) in ulong '1426878227.78'

The Nagios example (http://old.nagios.org/developerinfo/externalcommands/commandinfo.php?command_id=129) shows the use of `date +%s` to populate the time, which is an integer, so decimal is not likely expected.  Although Nagios 3.5.1 seems to be okay with this, Naemon does strong type checking and rejects it.