### PR TITLE
Replace obsolete mimetype with content_type

### DIFF
--- a/adagios/pnp/views.py
+++ b/adagios/pnp/views.py
@@ -31,9 +31,9 @@ def pnp(request, pnp_command='image'):
     c['messages'] = []
     c['errors'] = []
     result = run_pnp(pnp_command, **request.GET)
-    mimetype = "text"
+    content_type = "text"
     if pnp_command == 'image':
-        mimetype = "image/png"
+        content_type = "image/png"
     elif pnp_command == 'json':
-        mimetype = "application/json"
-    return HttpResponse(result, mimetype)
+        content_type = "application/json"
+    return HttpResponse(result, content_type=content_type)

--- a/adagios/rest/tests.py
+++ b/adagios/rest/tests.py
@@ -53,6 +53,15 @@ class LiveStatusTestCase(unittest.TestCase):
         except KeyError, e:
             self.assertEqual(True, _("Unhandled exception while loading %(path)s: %(exc)s") % {'path': path, 'exc': e})
 
+    def testGetAllHostsViaJSON(self):
+        """Test fetching hosts via json"""
+        path = "/rest/status/json/hosts"
+        data = {'fields': 'host_name'}
+        c = Client()
+        response = c.post(path=path, data=data)
+        json_data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200, _("Expected status code 200 for page %s") % path)
+        self.assertIn("localhost", [x['name'] for x in json_data])
 
     def loadPage(self, url):
         """ Load one specific page, and assert if return code is not 200 """

--- a/adagios/rest/views.py
+++ b/adagios/rest/views.py
@@ -95,21 +95,21 @@ def handle_request(request, module_name, module_path, attribute, format):
     if format == 'json':
         result = json.dumps(
             result, ensure_ascii=False, sort_keys=True, skipkeys=True, indent=4)
-        mimetype = 'application/javascript'
+        content_type = 'application/javascript'
     elif format == 'xml':
             # TODO: For some reason Ubuntu does not have this module. Where is
             # it? Should we use lxml instead ?
         import xml.marshal.generic
         result = xml.marshal.generic.dumps(result)
-        mimetype = 'application/xml'
+        content_type = 'application/xml'
     elif format == 'txt':
         result = str(result)
-        mimetype = 'text/plain'
+        content_type = 'text/plain'
     else:
         raise BaseException(
             _("Unsupported format: '%s'. Valid formats: json xml txt") %
             format)
-    return HttpResponse(result, mimetype=mimetype)
+    return HttpResponse(result, content_type=content_type)
 
 
 @adagios_decorator


### PR DESCRIPTION
HttpResponse in Django 1.7 no longer supports the mimetype argument and
uses content_type instead. Django 1.4 and later also support
content_type so this should have no effect.