### PR TITLE
Fix converting None to int

### DIFF
--- a/adagios/status/rest.py
+++ b/adagios/status/rest.py
@@ -287,11 +287,10 @@ def reschedule(request, host_name=None, service_description=None, check_time=Non
       check_time -- timestamp of when to execute this check, if left empty, execute right now
       wait -- If set to 1, function will not return until check has been rescheduled
     """
-
     if check_time is None or check_time is '':
-        check_time = int(time.time())
-    elif isinstance(check_time, float):
-        check_time = int(check_time)
+        check_time = time.time()
+
+    check_time = int(check_time)
 
     if service_description in (None, '', u'', '_HOST_', 'undefined'):
         service_description = ""

--- a/adagios/status/rest.py
+++ b/adagios/status/rest.py
@@ -262,14 +262,20 @@ def reschedule_many(request, hostlist, servicelist, check_time=None, **kwargs):
     """
     #task = adagios.utils.Task()
     #WaitCondition = "last_check > %s" % int(time.time()- 1)
+    if isinstance(check_time, float):
+        check_time = int(check_time)
+
     for i in hostlist.split(';'):
         if not i: continue
-        reschedule(request, host_name=i, service_description=None, check_time=int(check_time))
+        reschedule(request, host_name=i, service_description=None,
+                   check_time=check_time)
         #task.add(wait, 'hosts', i, WaitCondition)
     for i in servicelist.split(';'):
         if not i: continue
         host_name,service_description = i.split(',')
-        reschedule(request, host_name=host_name, service_description=service_description, check_time=int(check_time))
+        reschedule(request, host_name=host_name,
+                   service_description=service_description,
+                   check_time=check_time)
         #WaitObject = "{h};{s}".format(h=host_name, s=service_description)
         #task.add(wait, 'services', WaitObject, WaitCondition)
     return {'message': _("command sent successfully")}
@@ -286,7 +292,10 @@ def reschedule(request, host_name=None, service_description=None, check_time=Non
     """
 
     if check_time is None or check_time is '':
-        check_time = time.time()
+        check_time = int(time.time())
+    elif isinstance(check_time, float):
+        check_time = int(check_time)
+
     if service_description in (None, '', u'', '_HOST_', 'undefined'):
         service_description = ""
         pynag.Control.Command.schedule_forced_host_check(

--- a/adagios/status/rest.py
+++ b/adagios/status/rest.py
@@ -262,9 +262,6 @@ def reschedule_many(request, hostlist, servicelist, check_time=None, **kwargs):
     """
     #task = adagios.utils.Task()
     #WaitCondition = "last_check > %s" % int(time.time()- 1)
-    if isinstance(check_time, float):
-        check_time = int(check_time)
-
     for i in hostlist.split(';'):
         if not i: continue
         reschedule(request, host_name=i, service_description=None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mock


### PR DESCRIPTION
Now only coerces to int if check_time is a float when attempting reschedule.