### PR TITLE
Consistency of urls.py and enable bi.urls

### DIFF
--- a/adagios/bi/urls.py
+++ b/adagios/bi/urls.py
@@ -16,18 +16,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('adagios',
-                      (r'^/?$', 'bi.views.index'),
-                      (r'^/add/?$', 'bi.views.add'),
-                      (r'^/add/subprocess/?$', 'bi.views.add_subprocess'),
-                      (r'^/add/graph/?$', 'bi.views.add_graph'),
-                      (r'^/(?P<process_name>.+)/edit/status_method$', 'bi.views.change_status_calculation_method'),
-                      (r'^/edit/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.edit'),
-                      (r'^/json/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.json'),
-                      (r'^/graphs/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.graphs_json'),
-                      (r'^/delete/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.delete'),
-                      (r'^/view/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.view'),
+                      url(r'^/?$', 'bi.views.index'),
+                      url(r'^/add/?$', 'bi.views.add'),
+                      url(r'^/add/subprocess/?$', 'bi.views.add_subprocess'),
+                      url(r'^/add/graph/?$', 'bi.views.add_graph'),
+                      url(r'^/(?P<process_name>.+)/edit/status_method$', 'bi.views.change_status_calculation_method'),
+                      url(r'^/edit/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.edit'),
+                      url(r'^/json/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.json'),
+                      url(r'^/graphs/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.graphs_json'),
+                      url(r'^/delete/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.delete'),
+                      url(r'^/view/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.view'),
                       #(r'^/view/(?P<process_name>.+)/?$', 'bi.views.view'),
                        )
+

--- a/adagios/contrib/urls.py
+++ b/adagios/contrib/urls.py
@@ -16,12 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('adagios',
-                      (r'^/$', 'contrib.views.index'),
-                      (r'^/(?P<arg1>.+)?$', 'contrib.views.contrib'),
-                      (r'^/(?P<arg1>.+)/(?P<arg2>.+)/?$', 'contrib.views.contrib'),
-                      (r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/?$', 'contrib.views.contrib'),
-                      (r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/(?P<arg4>.+)/?$', 'contrib.views.contrib'),
+                      url(r'^/$', 'contrib.views.index'),
+                      url(r'^/(?P<arg1>.+)?$', 'contrib.views.contrib'),
+                      url(r'^/(?P<arg1>.+)/(?P<arg2>.+)/?$', 'contrib.views.contrib'),
+                      url(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/?$', 'contrib.views.contrib'),
+                      url(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/(?P<arg4>.+)/?$', 'contrib.views.contrib'),
                        )

--- a/adagios/misc/urls.py
+++ b/adagios/misc/urls.py
@@ -16,22 +16,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('',
-                      (r'^/test/?', 'adagios.misc.views.test'),
-                      (r'^/paste/?', 'adagios.misc.views.paste'),
-                      (r'^/?$', 'adagios.misc.views.index'),
+                      url(r'^/test/?', 'adagios.misc.views.test'),
+                      url(r'^/paste/?', 'adagios.misc.views.paste'),
+                      url(r'^/?$', 'adagios.misc.views.index'),
 
-                      (r'^/settings/?', 'adagios.misc.views.settings'),
-                      (r'^/preferences/?', 'adagios.misc.views.preferences'),
-                      (r'^/nagios/?', 'adagios.misc.views.nagios'),
-                      (r'^/iframe/?', 'adagios.misc.views.iframe'),
-                      (r'^/gitlog/?', 'adagios.misc.views.gitlog'),
-                      (r'^/service/?', 'adagios.misc.views.nagios_service'),
-                      (r'^/pnp4nagios/?$', 'adagios.misc.views.pnp4nagios'),
-                      (r'^/pnp4nagios/edit(?P<filename>.+)$', 'adagios.misc.views.pnp4nagios_edit_template'),
-                      (r'^/mail', 'adagios.misc.views.mail'),
-                       url(r'^/images/(?P<path>.+)$', 'django.views.static.serve', {'document_root': '/usr/share/nagios3/htdocs/images/logos/'}, name="logo"),
-                      (r'^/images/?$', 'adagios.misc.views.icons'),
+                      url(r'^/settings/?', 'adagios.misc.views.settings'),
+                      url(r'^/preferences/?', 'adagios.misc.views.preferences'),
+                      url(r'^/nagios/?', 'adagios.misc.views.nagios'),
+                      url(r'^/iframe/?', 'adagios.misc.views.iframe'),
+                      url(r'^/gitlog/?', 'adagios.misc.views.gitlog'),
+                      url(r'^/service/?', 'adagios.misc.views.nagios_service'),
+                      url(r'^/pnp4nagios/?$', 'adagios.misc.views.pnp4nagios'),
+                      url(r'^/pnp4nagios/edit(?P<filename>.+)$', 'adagios.misc.views.pnp4nagios_edit_template'),
+                      url(r'^/mail', 'adagios.misc.views.mail'),
+                      url(r'^/images/(?P<path>.+)$', 'django.views.static.serve', {'document_root': '/usr/share/nagios3/htdocs/images/logos/'}, name="logo"),
+                      url(r'^/images/?$', 'adagios.misc.views.icons'),
                       )

--- a/adagios/myapp/urls.py
+++ b/adagios/myapp/urls.py
@@ -18,7 +18,7 @@
 from django.conf.urls import url, patterns
 
 urlpatterns = patterns('adagios',
-                      (r'^/?$', 'myapp.views.hello_world'),
-                      (r'^/url1?$', 'myapp.views.hello_world'),
-                      (r'^/url2?$', 'myapp.views.hello_world'),
+                      url(r'^/?$', 'myapp.views.hello_world'),
+                      url(r'^/url1?$', 'myapp.views.hello_world'),
+                      url(r'^/url2?$', 'myapp.views.hello_world'),
                        )

--- a/adagios/okconfig_/urls.py
+++ b/adagios/okconfig_/urls.py
@@ -16,19 +16,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('adagios',
 
-                       #(r'^/?$', 'okconfig_.views.index'),
-                      (r'^/scan_network/?', 'okconfig_.views.scan_network'),
-                      (r'^/addgroup/?', 'okconfig_.views.addgroup'),
-                      (r'^/addtemplate/?', 'okconfig_.views.addtemplate'),
-                      (r'^/addhost/?', 'okconfig_.views.addhost'),
-                      (r'^/addservice/?', 'okconfig_.views.addservice'),
-                      (r'^/install_agent/?', 'okconfig_.views.install_agent'),
-                      (r'^/edit/?$', 'okconfig_.views.choose_host'),
-                      (r'^/edit/(?P<host_name>.+)$', 'okconfig_.views.edit'),
-                      (r'^/verify_okconfig/?',
+                      url(r'^/scan_network/?', 'okconfig_.views.scan_network'),
+                      url(r'^/addgroup/?', 'okconfig_.views.addgroup'),
+                      url(r'^/addtemplate/?', 'okconfig_.views.addtemplate'),
+                      url(r'^/addhost/?', 'okconfig_.views.addhost'),
+                      url(r'^/addservice/?', 'okconfig_.views.addservice'),
+                      url(r'^/install_agent/?', 'okconfig_.views.install_agent'),
+                      url(r'^/edit/?$', 'okconfig_.views.choose_host'),
+                      url(r'^/edit/(?P<host_name>.+)$', 'okconfig_.views.edit'),
+                      url(r'^/verify_okconfig/?',
                        'okconfig_.views.verify_okconfig'),
-                       )
+                      )

--- a/adagios/pnp/urls.py
+++ b/adagios/pnp/urls.py
@@ -16,8 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('adagios',
-                      (r'^/(?P<pnp_command>.+)?$', 'pnp.views.pnp'),
+                      url(r'^/(?P<pnp_command>.+)?$', 'pnp.views.pnp'),
                        )

--- a/adagios/rest/urls.py
+++ b/adagios/rest/urls.py
@@ -16,8 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
-
 
 urlpatterns = patterns('adagios',
                        url(r'^/?$', 'rest.views.list_modules'),

--- a/adagios/status/urls.py
+++ b/adagios/status/urls.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url, patterns
-from django.conf import settings
 
 urlpatterns = patterns('adagios',
                         url(r'^/?$', 'status.views.status_index'),

--- a/adagios/urls.py
+++ b/adagios/urls.py
@@ -30,6 +30,7 @@ urlpatterns = patterns(
     url(r'^403', 'adagios.views.http_403'),
     url(r'^objectbrowser', include('adagios.objectbrowser.urls')),
     url(r'^status', include('adagios.status.urls')),
+    url(r'^bi', include('adagios.bi.urls')),
     url(r'^misc', include('adagios.misc.urls')),
     url(r'^pnp', include('adagios.pnp.urls')),
     url(r'^media(?P<path>.*)$',         serve, {'document_root': settings.STATIC_ROOT }),


### PR DESCRIPTION
The use of url() was really inconsistent between urls.py files, made all of them use the same syntax. Also removed the import of adagios.settings where not needed.


Enable bi.urls by default


Is throwing template errors on '{% url "bi.views.index" %}' from base.html at least under gunicorn. I don't see a good reason for not enabling this.

Should take care of issue #538