### PR TITLE
Centralize reload_configfile code in settings

### DIFF
--- a/adagios/context_processors.py
+++ b/adagios/context_processors.py
@@ -345,10 +345,7 @@ def reload_configfile(request):
     """ Load the configfile from settings.adagios_configfile and put its content in adagios.settings. """
     try:
         clear_notification("configfile")
-        locals = {}
-        execfile(settings.adagios_configfile, globals(), locals)
-        for k, v in locals.items():
-            settings.__dict__[k] = v
+        settings.reload_configfile()
     except Exception, e:
         add_notification(
             level="warning", message=str(e), notification_id="configfile")

--- a/adagios/settings.py
+++ b/adagios/settings.py
@@ -277,21 +277,27 @@ PROFILE_LOG_BASE = "/var/lib/adagios"
 adagios_configfile = "/etc/adagios/adagios.conf"
 
 
-try:
-    if not os.path.exists(adagios_configfile):
-        alternative_adagios_configfile = "%s/adagios.conf" % djangopath
-        message = "Config file '{adagios_configfile}' not found. Using {alternative_adagios_configfile} instead."
-        warn(message.format(**locals()))
-        adagios_configfile = alternative_adagios_configfile
-        open(adagios_configfile, "a").close()
+def reload_configfile(adagios_configfile=None):
+    "Process adagios.conf style file and any includes; updating the settings"
+    if not adagios_configfile:
+        adagios_configfile = globals()['adagios_configfile']
+    try:
+        if not os.path.exists(adagios_configfile):
+            alternative_adagios_configfile = "%s/adagios.conf" % djangopath
+            message = "Config file '{adagios_configfile}' not found. Using {alternative_adagios_configfile} instead."
+            warn(message.format(**locals()))
+            adagios_configfile = alternative_adagios_configfile
+            open(adagios_configfile, "a").close()
 
-    execfile(adagios_configfile)
-    # if config has any default include, lets include that as well
-    configfiles = glob(include)
-    for configfile in configfiles:
-        execfile(configfile)
-except IOError, e:
-    warn('Unable to open %s: %s' % (adagios_configfile, e.strerror))
+        execfile(adagios_configfile, globals())
+        # if config has any default include, lets include that as well
+        configfiles = glob(include)
+        for configfile in configfiles:
+            execfile(configfile, globals())
+    except IOError, e:
+        warn('Unable to open %s: %s' % (adagios_configfile, e.strerror))
+
+reload_configfile()
 
 try:
     from django.utils.crypto import get_random_string

--- a/adagios/utils.py
+++ b/adagios/utils.py
@@ -110,22 +110,6 @@ def get_available_themes():
     return result
 
 
-def reload_config_file(adagios_configfile=None):
-    """ Reloads adagios.conf and populates updates adagios.settings accordingly.
-
-    Args:
-        adagios_configfile: Full path to adagios.conf. If None then use settings.adagios_configfile
-    """
-    if not adagios_configfile:
-        adagios_configfile = adagios.settings.adagios_configfile
-
-    # Using execfile might not be optimal outside strict settings.py usage, but
-    # lets do things exactly like settings.py does it.
-    execfile(adagios_configfile)
-    config_values = locals()
-    adagios.settings.__dict__.update(config_values)
-
-
 class FakeAdagiosEnvironment(pynag.Utils.misc.FakeNagiosEnvironment):
     _adagios_settings_copy = None
 
@@ -143,7 +127,8 @@ class FakeAdagiosEnvironment(pynag.Utils.misc.FakeNagiosEnvironment):
         adagios.settings.USER_PREFS_PATH = self.adagios_config_dir + "/userdata"
         adagios.settings.nagios_config = self.cfg_file
         adagios.settings.livestatus_path = self.livestatus_socket_path
-        reload_config_file(self.adagios_config_file)
+        adagios.settings.reload_configfile(self.adagios_config_file)
+
 
     def restore_adagios_global_variables(self):
         """ Restores adagios.settings so it looks like before update_adagios_global_variables() was called


### PR DESCRIPTION
Reading the config file `adagios.conf` into the adagios.settings
dictionary is slightly tricky (need to also process `include`
statement). Centralize this code in a function in `settings.py` and call
that function several times.

This should solve #555.