### PR TITLE
Fix directory for Git Event Handler. (EventHandlerError: fatal: Not a git repository (or any of the parent directories): .git)

### DIFF
--- a/adagios/objectbrowser/__init__.py
+++ b/adagios/objectbrowser/__init__.py
@@ -34,7 +34,7 @@ def startup():
 
     from pynag.Model import EventHandlers
     if settings.enable_githandler == True:
-        nagios_dir = os.path.dirname(pynag.Model.config.cfg_file)
+        nagios_dir = os.path.dirname(pynag.Model.cfg_file)
         githandler = pynag.Model.EventHandlers.GitEventHandler(nagios_dir, 'adagios', 'tommi')
         pynag.Model.eventhandlers.append(githandler)
     if settings.auto_reload:


### PR DESCRIPTION
When you enable Git support in Adagios, AND are using nonstandard
directory base (e.g. /etc/shinken instead of /etc/nagios), it
is not possible to create / edit configuration.
More specifically, each time Git Handler wants to commit something,
the Web UI fails with the following error:
EventHandlerError: fatal: Not a git repository (or any of the parent directories): .git

Root cause seems to be that the directory with which Git Handler
is configured is not the proper one, but a default one ( /etc/nagios ),
which is not under git control.

This (simple) fix aims to correct this.