### PR TITLE
ALLOWED_HOSTS variable added to django settings

### DIFF
--- a/adagios/etc/adagios/adagios.conf
+++ b/adagios/etc/adagios/adagios.conf
@@ -104,5 +104,13 @@ graphite_querystring = "target={host_}.{service_}.{metric_}&width=500&height=200
 # graphite_title - Put this string at the top of graphite graphs
 graphite_title = "{host} - {service} - {metric}"
 
+# A list of strings representing the host/domain names that this Django site can
+# serve. This is a security measure to prevent HTTP Host header attacks
+# Values in this list can be fully qualified names (e.g. www.example.com)
+# A value beginning with a period can be used as a subdomain wildcard:
+# '.example.com' will match example.com, www.example.com
+# A value of '*' will match anything
+# ALLOWED_HOSTS = ['*']
+
 # Include configuration options from these config files
 include="/etc/adagios/conf.d/*.conf"

--- a/adagios/settings.py
+++ b/adagios/settings.py
@@ -197,7 +197,13 @@ UNHANDLED_HOSTS = {
     'scheduled_downtime_depth': 0
 }
 
-
+# A list of strings representing the host/domain names that this Django site can
+# serve. This is a security measure to prevent HTTP Host header attacks
+# Values in this list can be fully qualified names (e.g. www.example.com)
+# A value beginning with a period can be used as a subdomain wildcard:
+# '.example.com' will match example.com, www.example.com
+# A value of '*' will match anything
+ALLOWED_HOSTS = ['*']
 
 # Graphite #
 


### PR DESCRIPTION
A list of strings representing the host/domain names that this Django site can serve. This is a security measure to prevent HTTP Host header attacks.