### PR TITLE
refactor: upgrade to Python 3.14.5 and Django 6.0.6 ...

### DIFF
--- a/adagios/auth.py
+++ b/adagios/auth.py
@@ -19,8 +19,6 @@
 
 """
 
-from builtins import str
-from builtins import object
 import adagios.status.utils
 import adagios.views
 
@@ -167,11 +165,18 @@ def check_role(request, role):
         raise adagios.exceptions.AccessDenied(username=user, access_required=role, message=message)
 
 
-class AuthorizationMiddleWare(object):
-    """ Django MiddleWare class. It's responsibility is to check if an adagios user has access
+class AuthorizationMiddleWare:
+    """ Django MiddleWare class. Its responsibility is to check if an adagios user has access.
 
-    if user does not have access to a given view, it is given a 403 error.
+    If user does not have access to a given view, it is given a 403 error.
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
     def process_request(self, request):
         return None
 

--- a/adagios/bi/__init__.py
+++ b/adagios/bi/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import division
 # Adagios is a web based Nagios configuration interface
 #
 # Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
@@ -16,9 +15,6 @@ from __future__ import division
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
-from builtins import object
-from past.utils import old_div
 from pynag.Utils import PynagError, defaultdict
 
 __author__ = 'palli'
@@ -30,7 +26,7 @@ import adagios.pnp.functions
 import adagios.settings
 import time
 import adagios.status.utils
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import socket
 
 
@@ -292,23 +288,23 @@ class BusinessProcess(object):
         elif macroname == 'percent_state_0':
             if len(self.get_all_states()) == 0:
                 return 0
-            return old_div(100.0 * state_summary[0], sum(state_summary))
+            return (100.0 * state_summary[0] / sum(state_summary))
         elif macroname == 'percent_state_1':
             if len(self.get_all_states()) == 0:
                 return 0
-            return old_div(100.0 * state_summary[1], sum(state_summary))
+            return (100.0 * state_summary[1] / sum(state_summary))
         elif macroname == 'percent_state_2':
             if len(self.get_all_states()) == 0:
                 return 0
-            return old_div(100.0 * state_summary[2], sum(state_summary))
+            return (100.0 * state_summary[2] / sum(state_summary))
         elif macroname == 'percent_state_3':
             if len(self.get_all_states()) == 0:
                 return 0
-            return old_div(100.0 * state_summary[3], sum(state_summary))
+            return (100.0 * state_summary[3] / sum(state_summary))
         elif macroname == 'percent_problems':
             if len(self.get_all_states()) == 0:
                 return 0
-            return old_div(100.0 * sum(state_summary[1:]), sum(state_summary))
+            return (100.0 * sum(state_summary[1:]) / sum(state_summary))
         elif macroname == 'current_state':
             return self.get_status()
         elif macroname == 'friendly_state':

--- a/adagios/bi/forms.py
+++ b/adagios/bi/forms.py
@@ -19,7 +19,7 @@
 
 
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import adagios.status.utils
 import adagios.bi
 

--- a/adagios/bi/tests.py
+++ b/adagios/bi/tests.py
@@ -30,7 +30,7 @@ import time
 
 from django.test import TestCase
 from django.test.client import Client
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from adagios.bi import *
 import adagios.utils

--- a/adagios/bi/urls.py
+++ b/adagios/bi/urls.py
@@ -1,33 +1,15 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.bi.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-                      url(r'^/?$', 'bi.views.index'),
-                      url(r'^/add/?$', 'bi.views.add'),
-                      url(r'^/add/subprocess/?$', 'bi.views.add_subprocess'),
-                      url(r'^/add/graph/?$', 'bi.views.add_graph'),
-                      url(r'^/(?P<process_name>.+)/edit/status_method$', 'bi.views.change_status_calculation_method'),
-                      url(r'^/edit/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.edit'),
-                      url(r'^/json/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.json'),
-                      url(r'^/graphs/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.graphs_json'),
-                      url(r'^/delete/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.delete'),
-                      url(r'^/view/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', 'bi.views.view'),
-                      #(r'^/view/(?P<process_name>.+)/?$', 'bi.views.view'),
-                       )
-
+urlpatterns = [
+    re_path(r'^/?$', adagios.bi.views.index),
+    re_path(r'^/add/?$', adagios.bi.views.add),
+    re_path(r'^/add/subprocess/?$', adagios.bi.views.add_subprocess),
+    re_path(r'^/add/graph/?$', adagios.bi.views.add_graph),
+    re_path(r'^/(?P<process_name>.+)/edit/status_method$', adagios.bi.views.change_status_calculation_method),
+    re_path(r'^/edit/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', adagios.bi.views.edit),
+    re_path(r'^/json/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', adagios.bi.views.json),
+    re_path(r'^/graphs/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', adagios.bi.views.graphs_json),
+    re_path(r'^/delete/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', adagios.bi.views.delete),
+    re_path(r'^/view/(?P<process_type>.+?)/(?P<process_name>.+?)/?$', adagios.bi.views.view),
+]

--- a/adagios/bi/views.py
+++ b/adagios/bi/views.py
@@ -17,11 +17,10 @@
 
 import simplejson
 from django.http import HttpResponse
-from django.shortcuts import render_to_response, redirect
-from django.template import RequestContext
-from django.core.context_processors import csrf
-from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+from django.shortcuts import render, redirect, redirect
+# csrf is handled automatically by Django middleware
+from django.urls import reverse
+from django.utils.translation import gettext as _
 from adagios.pnp.functions import run_pnp
 from adagios.views import adagios_decorator
 
@@ -82,7 +81,7 @@ def edit(request, process_name, process_type):
         # to it.
         bp = adagios.bi.get_business_process(process_name)
 
-    return render_to_response('business_process_edit.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'business_process_edit.html', locals())
 
 
 @adagios_decorator
@@ -131,7 +130,7 @@ def add_graph(request):
                 raise e
         return redirect('adagios.bi.views.edit', bp.process_type, bp.name)
 
-    return render_to_response('business_process_add_graph.html', c, context_instance=RequestContext(request))
+    return render(request, 'business_process_add_graph.html', c)
 
 
 @adagios_decorator
@@ -147,7 +146,7 @@ def view(request, process_name, process_type=None):
         'adagios.bi.views.graphs_json', kwargs={"process_type":process_type, "process_name": process_name})
     c['bp'] = bp
     c['graphs_url'] = graphs_url
-    return render_to_response('business_process_view.html', c, context_instance=RequestContext(request))
+    return render(request, 'business_process_view.html', c)
 
 
 @adagios_decorator
@@ -233,7 +232,7 @@ def add_subprocess(request):
         return redirect('adagios.bi.views.edit', bp.process_type, bp.name)
     c['subprocesses'] = process_list
     c['parameters'] = parameters
-    return render_to_response('business_process_add_subprocess.html', c, context_instance=RequestContext(request))
+    return render(request, 'business_process_add_subprocess.html', c)
 
 
 @adagios_decorator
@@ -254,7 +253,7 @@ def add(request):
         if form.is_valid():
             form.save()
             return redirect('adagios.bi.views.edit', bp.process_type, bp.name)
-    return render_to_response('business_process_edit.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'business_process_edit.html', locals())
 
 
 @adagios_decorator
@@ -265,7 +264,7 @@ def index(request):
     c['messages'] = []
     c['errors'] = []
     processes = adagios.bi.get_all_processes()
-    return render_to_response('business_process_list.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'business_process_list.html', locals())
 
 
 @adagios_decorator
@@ -279,7 +278,7 @@ def delete(request, process_name, process_type):
         form.delete()
         return redirect('adagios.bi.views.index')
 
-    return render_to_response('business_process_delete.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'business_process_delete.html', locals())
 
 
 @adagios_decorator

--- a/adagios/context_processors.py
+++ b/adagios/context_processors.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
 import pynag.Model
 import os
 import getpass
@@ -35,7 +34,7 @@ import datetime
 from adagios import __version__
 from adagios import userdata
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 def on_page_load(request):
     """ Collection of actions that take place every page load """
@@ -164,7 +163,7 @@ def get_current_settings(request):
 def resolve_urlname(request):
     """Allows us to see what the matched urlname for this
     request is within the template"""
-    from django.core.urlresolvers import resolve
+    from django.urls import resolve
     try:
         res = resolve(request.path_info)
         if res:

--- a/adagios/contrib/__init__.py
+++ b/adagios/contrib/__init__.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 def get_template_name(base_path, *args):
     """ Return a full path to a template named base_path/args[0]

--- a/adagios/contrib/urls.py
+++ b/adagios/contrib/urls.py
@@ -1,26 +1,10 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.contrib.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-                      url(r'^/$', 'contrib.views.index'),
-                      url(r'^/(?P<arg1>.+)?$', 'contrib.views.contrib'),
-                      url(r'^/(?P<arg1>.+)/(?P<arg2>.+)/?$', 'contrib.views.contrib'),
-                      url(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/?$', 'contrib.views.contrib'),
-                      url(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/(?P<arg4>.+)/?$', 'contrib.views.contrib'),
-                       )
+urlpatterns = [
+    re_path(r'^/$', adagios.contrib.views.index),
+    re_path(r'^/(?P<arg1>.+)?$', adagios.contrib.views.contrib),
+    re_path(r'^/(?P<arg1>.+)/(?P<arg2>.+)/?$', adagios.contrib.views.contrib),
+    re_path(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/?$', adagios.contrib.views.contrib),
+    re_path(r'^/(?P<arg1>.+)(?P<arg2>.+)/(?P<arg3>.+)/(?P<arg4>.+)/?$', adagios.contrib.views.contrib),
+]

--- a/adagios/contrib/views.py
+++ b/adagios/contrib/views.py
@@ -17,18 +17,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.core.context_processors import csrf
-from django.shortcuts import render_to_response
+# csrf is handled automatically by Django middleware
+from django.shortcuts import render, redirect
 from django.shortcuts import HttpResponse
 import adagios.settings
 import adagios.status.utils
 import os
 
 from adagios.views import adagios_decorator, error_page
-from django.template import RequestContext
 from adagios.contrib import get_template_name
 from django import template
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 @adagios_decorator
@@ -43,7 +42,7 @@ def index(request, contrib_dir=None):
 
     if not views:
         errors.append(_("Directory '%s' is empty") % contrib_dir)
-    return render_to_response("contrib_index.html", locals(), context_instance=RequestContext(request))
+    return render(request, "contrib_index.html", locals())
 
 
 @adagios_decorator
@@ -66,6 +65,6 @@ def contrib(request, arg1, arg2=None, arg3=None, arg4=None):
     statistics = lambda: locals().get('statistics', adagios.status.utils.get_statistics(request))
 
     t = template.Template(content)
-    c = RequestContext(request, locals())
+    c = locals()
     html = t.render(c)
     return HttpResponse(html)

--- a/adagios/misc/forms.py
+++ b/adagios/misc/forms.py
@@ -17,14 +17,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
 from django import forms
 
 from django.core.mail import send_mail
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import os.path
 from adagios import settings

--- a/adagios/misc/helpers.py
+++ b/adagios/misc/helpers.py
@@ -24,7 +24,6 @@ Convenient stateless functions for pynag. This module is used by the /rest/ inte
 """
 
 
-from builtins import str
 import platform
 import re
 from pynag import Model
@@ -34,7 +33,7 @@ from pynag import __version__
 from socket import gethostbyname_ex
 import adagios.settings
 from adagios.daemon import Daemon
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 #_config = Parsers.config(adagios.settings.nagios_config)

--- a/adagios/misc/rest.py
+++ b/adagios/misc/rest.py
@@ -23,11 +23,10 @@ This is a rest interface used by the "/rest/" module that affects adagios direct
 
 """
 
-from builtins import str
 from adagios import __version__, notifications, tasks
 from adagios.settings import plugins
 from adagios import userdata
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 version = __version__
 

--- a/adagios/misc/tests.py
+++ b/adagios/misc/tests.py
@@ -16,9 +16,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from django.test import TestCase
 from django.test.client import Client
 from django.test.client import RequestFactory

--- a/adagios/misc/urls.py
+++ b/adagios/misc/urls.py
@@ -1,36 +1,20 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+from django.views.static import serve
+import adagios.misc.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('',
-                      url(r'^/test/?', 'adagios.misc.views.test'),
-                      url(r'^/paste/?', 'adagios.misc.views.paste'),
-                      url(r'^/?$', 'adagios.misc.views.index'),
-
-                      url(r'^/settings/?', 'adagios.misc.views.settings'),
-                      url(r'^/preferences/?', 'adagios.misc.views.preferences'),
-                      url(r'^/nagios/?', 'adagios.misc.views.nagios'),
-                      url(r'^/iframe/?', 'adagios.misc.views.iframe'),
-                      url(r'^/gitlog/?', 'adagios.misc.views.gitlog'),
-                      url(r'^/service/?', 'adagios.misc.views.nagios_service'),
-                      url(r'^/pnp4nagios/?$', 'adagios.misc.views.pnp4nagios'),
-                      url(r'^/pnp4nagios/edit(?P<filename>.+)$', 'adagios.misc.views.pnp4nagios_edit_template'),
-                      url(r'^/mail', 'adagios.misc.views.mail'),
-                      url(r'^/images/(?P<path>.+)$', 'django.views.static.serve', {'document_root': '/usr/share/nagios3/htdocs/images/logos/'}, name="logo"),
-                      url(r'^/images/?$', 'adagios.misc.views.icons'),
-                      )
+urlpatterns = [
+    re_path(r'^/test/?', adagios.misc.views.test),
+    re_path(r'^/paste/?', adagios.misc.views.paste),
+    re_path(r'^/?$', adagios.misc.views.index),
+    re_path(r'^/settings/?', adagios.misc.views.settings),
+    re_path(r'^/preferences/?', adagios.misc.views.preferences),
+    re_path(r'^/nagios/?', adagios.misc.views.nagios),
+    re_path(r'^/iframe/?', adagios.misc.views.iframe),
+    re_path(r'^/gitlog/?', adagios.misc.views.gitlog),
+    re_path(r'^/service/?', adagios.misc.views.nagios_service),
+    re_path(r'^/pnp4nagios/?$', adagios.misc.views.pnp4nagios),
+    re_path(r'^/pnp4nagios/edit(?P<filename>.+)$', adagios.misc.views.pnp4nagios_edit_template),
+    re_path(r'^/mail', adagios.misc.views.mail),
+    re_path(r'^/images/(?P<path>.+)$', serve, {'document_root': '/usr/share/nagios3/htdocs/images/logos/'}, name="logo"),
+    re_path(r'^/images/?$', adagios.misc.views.icons),
+]

--- a/adagios/misc/views.py
+++ b/adagios/misc/views.py
@@ -17,14 +17,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.core.context_processors import csrf
+# csrf is handled automatically by Django middleware
 from django.forms.formsets import BaseFormSet
-from django.shortcuts import render_to_response
+from django.shortcuts import render, redirect
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django.shortcuts import HttpResponse
-from django.template import RequestContext
 from adagios.misc import forms
 import os
 import mimetypes
@@ -59,7 +58,7 @@ def index(request):
     c = {}
     c['nagios_cfg'] = pynag.Model.config.cfg_file
     c['version'] = __version__
-    return render_to_response('frontpage.html', c, context_instance=RequestContext(request))
+    return render(request, 'frontpage.html', c)
 
 @adagios_decorator
 def settings(request):
@@ -81,7 +80,7 @@ def settings(request):
     else:
         raise Exception(_("We only support methods GET or POST"))
     c['form'] = form
-    return render_to_response('settings.html', c, context_instance=RequestContext(request))
+    return render(request, 'settings.html', c)
 
 
 @adagios_decorator
@@ -92,7 +91,7 @@ def nagios(request):
 def iframe(request, url=None):
     if not url:
         url = request.GET.get('url', None)
-    return render_to_response('iframe.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'iframe.html', locals())
 
 
 @adagios_decorator
@@ -173,7 +172,7 @@ def gitlog(request):
             c['commit_id'] = commit
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('gitlog.html', c, context_instance=RequestContext(request))
+    return render(request, 'gitlog.html', c)
 
 
 @adagios_decorator
@@ -208,7 +207,7 @@ def nagios_service(request):
         c['friendly_status'] = "not running"
     needs_reload = pynag.Model.config.needs_reload()
     c['needs_reload'] = needs_reload
-    return render_to_response('nagios_service.html', c, context_instance=RequestContext(request))
+    return render(request, 'nagios_service.html', c)
 
 
 @adagios_decorator
@@ -250,7 +249,7 @@ def pnp4nagios(request):
             c['npcd_config'].save()
             m.append(_("npcd.cfg updated"))
 
-    return render_to_response('pnp4nagios.html', c, context_instance=RequestContext(request))
+    return render(request, 'pnp4nagios.html', c)
 
 
 @adagios_decorator
@@ -273,7 +272,7 @@ def edit_file(request, filename):
                 c['form'].save()
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('editfile.html', c, context_instance=RequestContext(request))
+    return render(request, 'editfile.html', c)
 
 
 @adagios_decorator
@@ -320,7 +319,7 @@ def icons(request, image_name=None):
     if not image_name:
         # Return a list of images
         c['images'] = filenames
-        return render_to_response('icons.html', c, context_instance=RequestContext(request))
+        return render(request, 'icons.html', c)
     else:
         if image_name in filenames:
             file_extension = image_name.split('.').pop()
@@ -392,7 +391,7 @@ def mail(request):
         request, "snippets/misc_mail_objectlist.html", c).content
     if request.method == 'POST' and c['form'].is_valid():
         c['form'].save()
-    return render_to_response('misc_mail.html', c, context_instance=RequestContext(request))
+    return render(request, 'misc_mail.html', c)
 
 
 
@@ -412,7 +411,7 @@ def test(request):
     else:
         c['form'] = forms.PluginOutputForm(initial=request.GET)
 
-    return render_to_response('test.html', c, context_instance=RequestContext(request))
+    return render(request, 'test.html', c)
 
 
 @adagios_decorator
@@ -431,7 +430,7 @@ def paste(request):
     else:
         c['form'] = forms.PasteForm(initial=request.GET)
 
-    return render_to_response('test2.html', c, context_instance=RequestContext(request))
+    return render(request, 'test2.html', c)
 
 @adagios_decorator
 def preferences(request):
@@ -451,4 +450,4 @@ def preferences(request):
     else:
         c['form'] = forms.UserdataForm(initial=user.to_dict())
 
-    return render_to_response('userdata.html', c, context_instance=RequestContext(request))
+    return render(request, 'userdata.html', c)

--- a/adagios/myapp/urls.py
+++ b/adagios/myapp/urls.py
@@ -1,24 +1,8 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.myapp.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-                      url(r'^/?$', 'myapp.views.hello_world'),
-                      url(r'^/url1?$', 'myapp.views.hello_world'),
-                      url(r'^/url2?$', 'myapp.views.hello_world'),
-                       )
+urlpatterns = [
+    re_path(r'^/?$', adagios.myapp.views.hello_world),
+    re_path(r'^/url1?$', adagios.myapp.views.hello_world),
+    re_path(r'^/url2?$', adagios.myapp.views.hello_world),
+]

--- a/adagios/myapp/views.py
+++ b/adagios/myapp/views.py
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Create your views here.
-from django.core.context_processors import csrf
-from django.shortcuts import render_to_response
+# csrf is handled automatically by Django middleware
+from django.shortcuts import render, redirect
 from django.shortcuts import HttpResponse
 from django.shortcuts import RequestContext
 
@@ -25,5 +25,5 @@ from django.shortcuts import RequestContext
 def hello_world(request):
     """ This is an example view. """
     c = {}
-    return render_to_response("myapp_helloworld.html", c, context_instance=RequestContext(request))
+    return render(request, "myapp_helloworld.html", c)
 

--- a/adagios/objectbrowser/forms.py
+++ b/adagios/objectbrowser/forms.py
@@ -18,13 +18,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #from __future__ import unicode_literals
-from builtins import str
-#from past.builtins import six.string_types
-from future.utils import string_types
+#from past.builtins import six.str
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from pynag import Model
 from pynag.Utils import AttributeList
@@ -133,7 +131,7 @@ class PynagAutoCompleteField(forms.CharField):
         """
         if value == 'null':
             return value
-        elif isinstance(value, string_types):
+        elif isinstance(value, str):
             a = AttributeList(value)
             self.__prefix = a.operator
             a.operator = ''
@@ -171,7 +169,7 @@ class PynagChoiceField(forms.MultipleChoiceField):
         """
         if value is None:
             return []
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             self.attributelist = AttributeList(value)
             self.__prefix = self.attributelist.operator
             return self.attributelist.fields

--- a/adagios/objectbrowser/help_text.py
+++ b/adagios/objectbrowser/help_text.py
@@ -23,7 +23,7 @@ This is an extends of pynag's all_attributes with friendly help message for all 
 """
 
 from pynag.Model.all_attributes import object_definitions
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 object_definitions["any"]["use"][

--- a/adagios/objectbrowser/tests.py
+++ b/adagios/objectbrowser/tests.py
@@ -16,13 +16,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from django.test import TestCase
 from django.test.client import Client
-from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.utils.translation import gettext as _
+from django.urls import reverse
 from django.http import QueryDict
 import pynag.Model
 import adagios.settings

--- a/adagios/objectbrowser/urls.py
+++ b/adagios/objectbrowser/urls.py
@@ -1,59 +1,34 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.objectbrowser.views
+import adagios.misc.views
 
-from django.conf.urls import url, patterns
-
-
-urlpatterns = patterns('adagios',
-
-    url(r'^/$', 'objectbrowser.views.list_object_types', name="objectbrowser"),
-
-    url(r'^/edit_all/(?P<object_type>.+)/(?P<attribute_name>.+)/?$', 'objectbrowser.views.edit_all'),
-    url(r'^/search/?$', 'objectbrowser.views.search_objects', name="search"),
-
-
-    url(r'^/edit/(?P<object_id>.+?)?$', 'objectbrowser.views.edit_object', name="edit_object"),
-    url(r'^/import/?$', 'objectbrowser.views.import_objects'),
-    url(r'^/edit/?$', 'objectbrowser.views.edit_object'),
-    url(r'^/copy_and_edit/(?P<object_id>.+?)?$', 'objectbrowser.views.copy_and_edit_object'),
-
-    url(r'^/copy/(?P<object_id>.+)$', 'objectbrowser.views.copy_object', name="copy_object"),
-    url(r'^/delete/(?P<object_id>.+)$', 'objectbrowser.views.delete_object', name="delete_object"),
-    url(r'^/delete/(?P<object_type>.+?)/(?P<shortname>.+)/?$', 'objectbrowser.views.delete_object_by_shortname', name="delete_by_shortname"),
-
-    url(r'^/add/(?P<object_type>.+)$', 'objectbrowser.views.add_object', name="addobject"),
-    url(r'^/bulk_edit/?$', 'objectbrowser.views.bulk_edit', name='bulk_edit'),
-    url(r'^/bulk_delete/?$', 'objectbrowser.views.bulk_delete', name='bulk_delete'),
-    url(r'^/bulk_copy/?$', 'objectbrowser.views.bulk_copy', name='bulk_copy'),
-    url(r'^/add_to_group/(?P<group_type>.+)/(?P<group_name>.+)/?$', 'objectbrowser.views.add_to_group'),
-    url(r'^/add_to_group/(?P<group_type>.+)/?$', 'objectbrowser.views.add_to_group'),
-    url(r'^/add_to_group', 'objectbrowser.views.add_to_group'),
-    url(r'^/plugins/?$', 'objectbrowser.views.show_plugins'),
-    url(r'^/nagios.cfg/?$', 'objectbrowser.views.edit_nagios_cfg'),
-    url(r'^/nagios.cfg/edit/?$', 'misc.views.edit_nagios_cfg'),
-    url(r'^/geek_edit/id=(?P<object_id>.+)$', 'objectbrowser.views.geek_edit'),
-    url(r'^/advanced_edit/id=(?P<object_id>.+)$', 'objectbrowser.views.advanced_edit'),
-
-    # Here for backwards compatibility.
-    url(r'^/edit/id=(?P<object_id>.+)$', 'objectbrowser.views.edit_object', ),
-    url(r'^/id=(?P<object_id>.+)$', 'objectbrowser.views.edit_object', ),
-
-    # These should be deprecated as of 2012-08-27
-    url(r'^/copy_object/id=(?P<object_id>.+)$', 'objectbrowser.views.copy_object'),
-    url(r'^/delete_object/id=(?P<object_id>.+)$', 'objectbrowser.views.delete_object'),
-
-    )
+urlpatterns = [
+    re_path(r'^/$', adagios.objectbrowser.views.list_object_types, name="objectbrowser"),
+    re_path(r'^/edit_all/(?P<object_type>.+)/(?P<attribute_name>.+)/?$', adagios.objectbrowser.views.edit_all),
+    re_path(r'^/search/?$', adagios.objectbrowser.views.search_objects, name="search"),
+    re_path(r'^/edit/(?P<object_id>.+?)?$', adagios.objectbrowser.views.edit_object, name="edit_object"),
+    re_path(r'^/import/?$', adagios.objectbrowser.views.import_objects),
+    re_path(r'^/edit/?$', adagios.objectbrowser.views.edit_object),
+    re_path(r'^/copy_and_edit/(?P<object_id>.+?)?$', adagios.objectbrowser.views.copy_and_edit_object),
+    re_path(r'^/copy/(?P<object_id>.+)$', adagios.objectbrowser.views.copy_object, name="copy_object"),
+    re_path(r'^/delete/(?P<object_id>.+)$', adagios.objectbrowser.views.delete_object, name="delete_object"),
+    re_path(r'^/delete/(?P<object_type>.+?)/(?P<shortname>.+)/?$', adagios.objectbrowser.views.delete_object_by_shortname, name="delete_by_shortname"),
+    re_path(r'^/add/(?P<object_type>.+)$', adagios.objectbrowser.views.add_object, name="addobject"),
+    re_path(r'^/bulk_edit/?$', adagios.objectbrowser.views.bulk_edit, name='bulk_edit'),
+    re_path(r'^/bulk_delete/?$', adagios.objectbrowser.views.bulk_delete, name='bulk_delete'),
+    re_path(r'^/bulk_copy/?$', adagios.objectbrowser.views.bulk_copy, name='bulk_copy'),
+    re_path(r'^/add_to_group/(?P<group_type>.+)/(?P<group_name>.+)/?$', adagios.objectbrowser.views.add_to_group),
+    re_path(r'^/add_to_group/(?P<group_type>.+)/?$', adagios.objectbrowser.views.add_to_group),
+    re_path(r'^/add_to_group', adagios.objectbrowser.views.add_to_group),
+    re_path(r'^/plugins/?$', adagios.objectbrowser.views.show_plugins),
+    re_path(r'^/nagios.cfg/?$', adagios.objectbrowser.views.edit_nagios_cfg),
+    re_path(r'^/nagios.cfg/edit/?$', adagios.misc.views.edit_nagios_cfg),
+    re_path(r'^/geek_edit/id=(?P<object_id>.+)$', adagios.objectbrowser.views.geek_edit),
+    re_path(r'^/advanced_edit/id=(?P<object_id>.+)$', adagios.objectbrowser.views.advanced_edit),
+    # Backwards compatibility
+    re_path(r'^/edit/id=(?P<object_id>.+)$', adagios.objectbrowser.views.edit_object),
+    re_path(r'^/id=(?P<object_id>.+)$', adagios.objectbrowser.views.edit_object),
+    # Deprecated
+    re_path(r'^/copy_object/id=(?P<object_id>.+)$', adagios.objectbrowser.views.copy_object),
+    re_path(r'^/delete_object/id=(?P<object_id>.+)$', adagios.objectbrowser.views.delete_object),
+]

--- a/adagios/objectbrowser/views.py
+++ b/adagios/objectbrowser/views.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
-from django.shortcuts import render_to_response, redirect, HttpResponse, Http404
+from django.shortcuts import render, redirect, redirect, HttpResponse, Http404
 from django.http import HttpResponseRedirect
-from django.template import RequestContext
-from django.core.context_processors import csrf
-from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+# csrf is handled automatically by Django middleware
+from django.urls import reverse
+from django.utils.translation import gettext as _
 import os
 from os.path import dirname
 
@@ -48,7 +46,7 @@ def home(request):
 def list_object_types(request):
     """ Collects statistics about pynag objects and returns to template """
     c = {}
-    return render_to_response('list_object_types.html', c, context_instance=RequestContext(request))
+    return render(request, 'list_object_types.html', c)
 
 
 @adagios_decorator
@@ -74,7 +72,7 @@ def geek_edit(request, object_id):
         else:
             c['error_summary'] = _('Unable to find object')
             c['error'] = e
-            return render_to_response('error.html', c, context_instance=RequestContext(request))
+            return render(request, 'error.html', c)
     c['my_object'] = o
     if request.method == 'POST':
         # Manual edit of the form
@@ -85,10 +83,10 @@ def geek_edit(request, object_id):
                 m.append("Object Saved manually to '%s'" % o['filename'])
             except Exception as e:
                 c['errors'].append(e)
-                return render_to_response('edit_object.html', c, context_instance=RequestContext(request))
+                return render(request, 'edit_object.html', c)
         else:
             c['errors'].append(_("Problem with saving object"))
-            return render_to_response('edit_object.html', c, context_instance=RequestContext(request))
+            return render(request, 'edit_object.html', c)
     else:
         form = GeekEditObjectForm(
             initial={'definition': o['meta']['raw_definition'], })
@@ -121,7 +119,7 @@ def advanced_edit(request, object_id):
         else:
             c['error_summary'] = _('Unable to get object')
             c['error'] = e
-            return render_to_response('error.html', c, context_instance=RequestContext(request))
+            return render(request, 'error.html', c)
 
     if request.method == 'POST':
         # User is posting data into our form
@@ -133,10 +131,10 @@ def advanced_edit(request, object_id):
                 m.append(_("Object Saved to %(filename)s") % o)
             except Exception as e:
                 c['errors'].append(e)
-                return render_to_response('edit_object.html', c, context_instance=RequestContext(request))
+                return render(request, 'edit_object.html', c)
     else:
             c['errors'].append(_("Problem reading form input"))
-            return render_to_response('edit_object.html', c, context_instance=RequestContext(request))
+            return render(request, 'edit_object.html', c)
 
     return HttpResponseRedirect(reverse('edit_object', args=[o.get_id()]))
 
@@ -168,7 +166,7 @@ def edit_object(request, object_id=None):
         except KeyError:
             c['error_summary'] = _('Could not find any object with id="%(object_id)s" :/') % {'object_id': object_id}
             c['error_type'] = _("object not found")
-            return render_to_response('error.html', c, context_instance=RequestContext(request))
+            return render(request, 'error.html', c)
 
     if request.method == 'POST':
         # User is posting data into our form
@@ -233,7 +231,7 @@ def edit_object(request, object_id=None):
     elif my_object['object_type'] == 'timeperiod':
         return _edit_timeperiod(request, c)
     else:
-        return render_to_response('edit_object.html', c, context_instance=RequestContext(request))
+        return render(request, 'edit_object.html', c)
 
 
 @pynag.Utils.cache_only
@@ -245,7 +243,7 @@ def _edit_contact(request, c):
     except KeyError as e:
         c['errors'].append(_("Could not find contact: %(error)s") % {'error': str(e)})
 
-    return render_to_response('edit_contact.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_contact.html', c)
 
 
 @pynag.Utils.cache_only
@@ -322,7 +320,7 @@ def _edit_service(request, c):
     host_name = service.host_name or ''
     if ',' in host_name:
         c['errors'].append(_("This Service is applied to multiple hosts"))
-    return render_to_response('edit_service.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_service.html', c)
 
 
 @pynag.Utils.cache_only
@@ -344,7 +342,7 @@ def _edit_contactgroup(request, c):
             contactgroup_members__has_field=c['my_object'].contactgroup_name)
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('edit_contactgroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_contactgroup.html', c)
 
 
 @pynag.Utils.cache_only
@@ -361,7 +359,7 @@ def _edit_hostgroup(request, c):
             hostgroup_members__has_field=c['my_object'].hostgroup_name)
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('edit_hostgroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_hostgroup.html', c)
 
 
 @pynag.Utils.cache_only
@@ -372,31 +370,31 @@ def _edit_servicegroup(request, c):
             servicegroup_members__has_field=c['my_object'].servicegroup_name)
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('edit_servicegroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_servicegroup.html', c)
 
 
 @pynag.Utils.cache_only
 def _edit_command(request, c):
     """ This is a helper function to edit_object """
-    return render_to_response('edit_command.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_command.html', c)
 
 
 @pynag.Utils.cache_only
 def _edit_hostdependency(request, c):
     """ This is a helper function to edit_object """
-    return render_to_response('edit_hostdepedency.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_hostdepedency.html', c)
 
 
 @pynag.Utils.cache_only
 def _edit_servicedependency(request, c):
     """ This is a helper function to edit_object """
-    return render_to_response('_edit_servicedependency.html', c, context_instance=RequestContext(request))
+    return render(request, '_edit_servicedependency.html', c)
 
 
 @pynag.Utils.cache_only
 def _edit_timeperiod(request, c):
     """ This is a helper function to edit_object """
-    return render_to_response('edit_timeperiod.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_timeperiod.html', c)
 
 
 @pynag.Utils.cache_only
@@ -457,7 +455,7 @@ def _edit_host(request, c):
     except Exception:
         pass
 
-    return render_to_response('edit_host.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_host.html', c)
 
 @adagios_decorator
 def show_plugins(request):
@@ -491,7 +489,7 @@ def show_plugins(request):
             missing_plugins.append((check_command, command_name))
     c['missing_plugins'] = missing_plugins
     c['existing_plugins'] = existing_plugins
-    return render_to_response('show_plugins.html', c, context_instance=RequestContext(request))
+    return render(request, 'show_plugins.html', c)
 
 
 @adagios_decorator
@@ -528,7 +526,7 @@ def edit_nagios_cfg(request):
                        'mispelled.')
             })
     c['content'] = sorted(c['content'], key=lambda cfgitem: cfgitem['key'])
-    return render_to_response('edit_configfile.html', c, context_instance=RequestContext(request))
+    return render(request, 'edit_configfile.html', c)
 
 
 @adagios_decorator
@@ -565,7 +563,7 @@ def bulk_edit(request):
             except IOError as e:
                 c['errors'].append(e)
 
-    return render_to_response('bulk_edit.html', c, context_instance=RequestContext(request))
+    return render(request, 'bulk_edit.html', c)
 
 @adagios_decorator
 def bulk_delete(request):
@@ -613,7 +611,7 @@ def bulk_delete(request):
             except IOError as e:
                 c['errors'].append(e)
 
-    return render_to_response('bulk_delete.html', c, context_instance=RequestContext(request))
+    return render(request, 'bulk_delete.html', c)
 
 @adagios_decorator
 def bulk_copy(request):
@@ -661,7 +659,7 @@ def bulk_copy(request):
             except IOError as e:
                 c['errors'].append(e)
 
-    return render_to_response('bulk_copy.html', c, context_instance=RequestContext(request))
+    return render(request, 'bulk_copy.html', c)
 
 @adagios_decorator
 def delete_object_by_shortname(request, object_type, shortname):
@@ -689,7 +687,7 @@ def delete_object(request, object_id):
             return HttpResponseRedirect(reverse('objectbrowser') + "#" + my_obj.object_type)
         except Exception as e:
             c['errors'].append(e)
-    return render_to_response('delete_object.html', c, context_instance=RequestContext(request))
+    return render(request, 'delete_object.html', c)
 
 
 @adagios_decorator
@@ -712,7 +710,7 @@ def copy_object(request, object_id):
                 c['success'] = 'success'
             except IndexError as e:
                 c['errors'].append(e)
-    return render_to_response('copy_object.html', c, context_instance=RequestContext(request))
+    return render(request, 'copy_object.html', c)
 
 
 @adagios_decorator
@@ -745,7 +743,7 @@ def add_object(request, object_type):
         else:
             c['errors'].append(_('Could not validate form input'))
 
-    return render_to_response('add_object.html', c, context_instance=RequestContext(request))
+    return render(request, 'add_object.html', c)
 
 
 def _querystring_to_objects(dictionary):
@@ -853,7 +851,7 @@ def add_to_group(request, group_type=None, group_name=''):
                                                                                            'error': error,
                                                                                            })
 
-    return render_to_response('add_to_group.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'add_to_group.html', locals())
 
 
 @adagios_decorator
@@ -867,7 +865,7 @@ def edit_all(request, object_type, attribute_name):
     errors = []
     objects = Model.string_to_class.get(object_type).objects.all
     objects = [(x.get_shortname, x.get(attribute_name)) for x in objects]
-    return render_to_response('edit_all.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'edit_all.html', locals())
 
 
 
@@ -903,7 +901,7 @@ def search_objects(request, objects=None):
         services = [_find_service(host_name, service_description)]
         errors.append(_('be careful'))
 
-    return render_to_response('search_objects.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'search_objects.html', locals())
 
 
 @adagios_decorator
@@ -935,4 +933,4 @@ def import_objects(request):
                     saved_objects = form.save()
     else:
         form = ImportObjectsForm(initial=request.GET)
-    return render_to_response('import_objects.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'import_objects.html', locals())

--- a/adagios/okconfig_/forms.py
+++ b/adagios/okconfig_/forms.py
@@ -23,7 +23,7 @@ from django.core.exceptions import ValidationError
 import socket
 from pynag import Model
 from adagios.forms import AdagiosForm
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 def get_all_hosts():

--- a/adagios/okconfig_/tests.py
+++ b/adagios/okconfig_/tests.py
@@ -19,7 +19,7 @@
 
 from django.test import TestCase
 from django.test.client import Client
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import okconfig
 import adagios.settings

--- a/adagios/okconfig_/urls.py
+++ b/adagios/okconfig_/urls.py
@@ -1,32 +1,14 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.okconfig_.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-
-                      url(r'^/scan_network/?', 'okconfig_.views.scan_network'),
-                      url(r'^/addgroup/?', 'okconfig_.views.addgroup'),
-                      url(r'^/addtemplate/?', 'okconfig_.views.addtemplate'),
-                      url(r'^/addhost/?', 'okconfig_.views.addhost'),
-                      url(r'^/addservice/?', 'okconfig_.views.addservice'),
-                      url(r'^/install_agent/?', 'okconfig_.views.install_agent'),
-                      url(r'^/edit/?$', 'okconfig_.views.choose_host'),
-                      url(r'^/edit/(?P<host_name>.+)$', 'okconfig_.views.edit'),
-                      url(r'^/verify_okconfig/?',
-                       'okconfig_.views.verify_okconfig'),
-                      )
+urlpatterns = [
+    re_path(r'^/scan_network/?', adagios.okconfig_.views.scan_network),
+    re_path(r'^/addgroup/?', adagios.okconfig_.views.addgroup),
+    re_path(r'^/addtemplate/?', adagios.okconfig_.views.addtemplate),
+    re_path(r'^/addhost/?', adagios.okconfig_.views.addhost),
+    re_path(r'^/addservice/?', adagios.okconfig_.views.addservice),
+    re_path(r'^/install_agent/?', adagios.okconfig_.views.install_agent),
+    re_path(r'^/edit/?$', adagios.okconfig_.views.choose_host),
+    re_path(r'^/edit/(?P<host_name>.+)$', adagios.okconfig_.views.edit),
+    re_path(r'^/verify_okconfig/?', adagios.okconfig_.views.verify_okconfig),
+]

--- a/adagios/okconfig_/views.py
+++ b/adagios/okconfig_/views.py
@@ -17,15 +17,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.shortcuts import render_to_response, redirect
+from django.shortcuts import render, redirect, redirect
 from django.core import serializers
 from django.http import HttpResponse, HttpResponseServerError, HttpResponseRedirect
-from django.core.context_processors import csrf
-from django.template import RequestContext
-from django.utils.translation import ugettext as _
+# csrf is handled automatically by Django middleware
+from django.utils.translation import gettext as _
 from adagios.views import adagios_decorator
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from adagios.okconfig_ import forms
 
@@ -40,7 +39,7 @@ def addcomplete(request, c=None):
     """
     if not c:
         c = {}
-    return render_to_response('addcomplete.html', c, context_instance=RequestContext(request))
+    return render(request, 'addcomplete.html', c)
 
 
 @adagios_decorator
@@ -75,7 +74,7 @@ def addgroup(request):
     else:
         raise Exception("Sorry i only support GET or POST")
     c['form'] = f
-    return render_to_response('addgroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'addgroup.html', c)
 
 
 @adagios_decorator
@@ -112,7 +111,7 @@ def addhost(request):
     else:
         raise Exception("Sorry i only support GET or POST")
     c['form'] = f
-    return render_to_response('addhost.html', c, context_instance=RequestContext(request))
+    return render(request, 'addhost.html', c)
 
 
 @adagios_decorator
@@ -142,7 +141,7 @@ def addtemplate(request, host_name=None):
                 c['errors'].append(e)
         else:
             c['errors'].append(_("Could not validate form"))
-    return render_to_response('addtemplate.html', c, context_instance=RequestContext(request))
+    return render(request, 'addtemplate.html', c)
 
 
 @adagios_decorator
@@ -179,7 +178,7 @@ def addservice(request):
                 c['errors'].append(e)
         else:
             c['errors'].append(_("Could not validate form"))
-    return render_to_response('addservice.html', c, context_instance=RequestContext(request))
+    return render(request, 'addservice.html', c)
 
 
 @adagios_decorator
@@ -193,7 +192,7 @@ def verify_okconfig(request):
             c['errors'].append(
                 _('There seems to be a problem with your okconfig installation'))
             break
-    return render_to_response('verify_okconfig.html', c, context_instance=RequestContext(request))
+    return render(request, 'verify_okconfig.html', c)
 
 
 @adagios_decorator
@@ -242,7 +241,7 @@ def install_agent(request):
         else:
             c['errors'].append(_('invalid input'))
 
-    return render_to_response('install_agent.html', c, context_instance=RequestContext(request))
+    return render(request, 'install_agent.html', c)
 
 
 @adagios_decorator
@@ -261,7 +260,7 @@ def edit(request, host_name):
         c['myhost'] = Model.Host.objects.get_by_shortname(host_name)
     except KeyError as e:
         c['errors'].append(_("Host %s not found") % e)
-        return render_to_response('edittemplate.html', c, context_instance=RequestContext(request))
+        return render(request, 'edittemplate.html', c)
     # Get all services of that host that contain a service_description
     services = Model.Service.objects.filter(
         host_name=host_name, service_description__contains='')
@@ -287,7 +286,7 @@ def edit(request, host_name):
                 c['errors'].append(
                     _('invalid data in %s') % service.get_description())
         c['forms'] = myforms
-    return render_to_response('edittemplate.html', c, context_instance=RequestContext(request))
+    return render(request, 'edittemplate.html', c)
 
 
 @adagios_decorator
@@ -302,7 +301,7 @@ def choose_host(request):
         if c['form'].is_valid():
             host_name = c['form'].cleaned_data['host_name']
             return HttpResponseRedirect(reverse("adagios.okconfig_.views.edit", args=[host_name]))
-    return render_to_response('choosehost.html', c, context_instance=RequestContext(request))
+    return render(request, 'choosehost.html', c)
 
 
 @adagios_decorator
@@ -334,4 +333,4 @@ def scan_network(request):
                     i.check()
             except Exception as e:
                 c['errors'].append(_("Error running scan"))
-    return render_to_response('scan_network.html', c, context_instance=RequestContext(request))
+    return render(request, 'scan_network.html', c)

--- a/adagios/pnp/functions.py
+++ b/adagios/pnp/functions.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
 import os
 
 import pynag.Utils
@@ -23,7 +22,7 @@ from pynag.Utils import PynagError
 from adagios import settings
 import subprocess
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 def run_pnp(pnp_command, **kwargs):

--- a/adagios/pnp/tests.py
+++ b/adagios/pnp/tests.py
@@ -22,7 +22,7 @@ import os
 import unittest
 #from django.test import TestCase
 from django.test.client import Client
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import pynag.Parsers
 from adagios.settings import nagios_config

--- a/adagios/pnp/urls.py
+++ b/adagios/pnp/urls.py
@@ -1,22 +1,6 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.pnp.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-                      url(r'^/(?P<pnp_command>.+)?$', 'pnp.views.pnp'),
-                       )
+urlpatterns = [
+    re_path(r'^/(?P<pnp_command>.+)?$', adagios.pnp.views.pnp),
+]

--- a/adagios/pnp/views.py
+++ b/adagios/pnp/views.py
@@ -17,8 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.core.context_processors import csrf
-from django.shortcuts import render_to_response
+# csrf is handled automatically by Django middleware
+from django.shortcuts import render, redirect
 from django.shortcuts import HttpResponse
 from adagios.pnp.functions import run_pnp
 from adagios.views import adagios_decorator

--- a/adagios/profiling.py
+++ b/adagios/profiling.py
@@ -24,8 +24,6 @@
 # https://github.com/opinkerfi/adagios/wiki/Profiling-Decorators-within-Adagios
 
 
-from __future__ import absolute_import
-from builtins import str
 import cProfile
 import os
 import time

--- a/adagios/rest/tests.py
+++ b/adagios/rest/tests.py
@@ -21,12 +21,10 @@ unittest). These will both pass when you run "manage.py test".
 
 Replace these with more appropriate tests for your application.
 """
-from __future__ import unicode_literals
 #from django.utils.encoding import force_text
-from builtins import str
 from django.test import TestCase
 from django.test.client import Client, RequestFactory
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import json
 import sys
 

--- a/adagios/rest/urls.py
+++ b/adagios/rest/urls.py
@@ -1,50 +1,22 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.rest.views
 
-from django.conf.urls import url, patterns
+urlpatterns = [
+    re_path(r'^/?$', adagios.rest.views.list_modules),
+]
 
-urlpatterns = patterns('adagios',
-                       url(r'^/?$', 'rest.views.list_modules'),
-                       )
-
-
-
-# Example:
-# rest_modules['module_name'] = 'module_path'
-# will make /adagios/rest/module_name/ available and it loads all
-# functions from 'module_path'
-
-rest_modules = {}
-rest_modules['pynag'] = 'adagios.misc.helpers'
-rest_modules['okconfig'] = 'okconfig'
-rest_modules['status'] = 'adagios.rest.status'
-rest_modules['adagios'] = 'adagios.misc.rest'
-
-
-# We are going to generate some url patterns, for clarification here is the end result shown for the status module:
-#url(r'^/status/$', 'rest.views.index', { 'module_name': 'adagios.rest.status'    }, name="rest/status"),
-#url(r'^/status.js$', 'rest.views.javascript', { 'module_name': 'adagios.rest.status'    }, ),
-#(r'^/status/(?P<format>.+?)/(?P<attribute>.+?)/?$', 'rest.views.handle_request', { 'module_name': 'adagios.rest.status' }),
+rest_modules = {
+    'pynag': 'adagios.misc.helpers',
+    'okconfig': 'okconfig',
+    'status': 'adagios.rest.status',
+    'adagios': 'adagios.misc.rest',
+}
 
 for module_name, module_path in list(rest_modules.items()):
     base_pattern = r'^/%s' % module_name
     args = {'module_name': module_name, 'module_path': module_path}
-    urlpatterns += patterns('adagios',
-        url(base_pattern + '/$',   'rest.views.index', args, name="rest/%s" % module_name),
-        url(base_pattern + '.js$', 'rest.views.javascript', args, ),
-        url(base_pattern + '/(?P<format>.+?)/(?P<attribute>.+?)/?$', 'rest.views.handle_request', args),
-    )
+    urlpatterns += [
+        re_path(base_pattern + r'/$',   adagios.rest.views.index, args, name="rest/%s" % module_name),
+        re_path(base_pattern + r'.js$', adagios.rest.views.javascript, args),
+        re_path(base_pattern + r'/(?P<format>.+?)/(?P<attribute>.+?)/?$', adagios.rest.views.handle_request, args),
+    ]

--- a/adagios/rest/views.py
+++ b/adagios/rest/views.py
@@ -16,21 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Create your views here.
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from past.builtins import cmp
-from future.utils import string_types
-from builtins import map
-from builtins import str
-from django.shortcuts import render_to_response, redirect, render
+from django.shortcuts import render, redirect
 from django.core import serializers
 from django.http import HttpResponse, HttpResponseServerError
 import json
-#from django.core.context_processors import csrf
+## csrf is handled automatically by Django middleware
 from django.views.decorators.csrf import csrf_exempt
-from django.template import RequestContext
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from adagios.views import adagios_decorator
 
 import inspect
@@ -69,7 +61,7 @@ def handle_request(request, module_name, module_path, attribute, format):
             c['docstring'] = docstring
             c['module_name'] = module_name
             if not list(request.GET.items()):
-                return render_to_response('function_form.html', c, context_instance=RequestContext(request))
+                return render(request, 'function_form.html', c)
             # Handle get parameters
             arguments = {}
             for k, v in list(request.GET.items()):
@@ -125,7 +117,7 @@ def list_modules(request):
 
     """
     rest_modules = adagios.rest.urls.rest_modules
-    return render_to_response('list_modules.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'list_modules.html', locals())
 
 
 @adagios_decorator
@@ -151,7 +143,7 @@ def index(request, module_name, module_path):
     c['gets'] = gets
     c['puts'] = puts
     c['module_documenation'] = inspect.getdoc(m)
-    return render_to_response('index.html', c, context_instance=RequestContext(request))
+    return render(request, 'index.html', c)
 
 
 def javascript(request, module_name, module_path):

--- a/adagios/seleniumtests.py
+++ b/adagios/seleniumtests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from django.test import LiveServerTestCase
 from django.test import TestCase
 import adagios.settings

--- a/adagios/settings.py
+++ b/adagios/settings.py
@@ -17,9 +17,7 @@
 
 # Django settings for adagios project.
 
-from past.builtins import execfile
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 USE_TZ = True
 
 # Hack to allow relative template paths
@@ -83,20 +81,35 @@ STATIC_ROOT = '%s/media/' % djangopath
 #ADMIN_MEDIA_PREFIX = '/media/'
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            "%s/templates" % djangopath,
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'adagios.context_processors.on_page_load',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.static',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'adagios.auth.AuthorizationMiddleWare',
-    #'django.contrib.auth.middleware.AuthenticationMiddleware',
-    #'django.contrib.messages.middleware.MessageMiddleware',
-)
+    # 'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # 'django.contrib.messages.middleware.MessageMiddleware',
+]
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 
@@ -110,13 +123,6 @@ LOCALE_PATHS = (
 )
 
 ROOT_URLCONF = 'adagios.urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    "%s/templates" % (djangopath),
-)
 
 INSTALLED_APPS = [
     #'django.contrib.auth',
@@ -136,14 +142,7 @@ INSTALLED_APPS = [
     'adagios.contrib',
 ]
 
-TEMPLATE_CONTEXT_PROCESSORS = ('adagios.context_processors.on_page_load',
-    #"django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    #"django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.core.context_processors.request",
-    "django.contrib.messages.context_processors.messages")
+
 
 
 # Themes options #
@@ -298,11 +297,11 @@ def reload_configfile(adagios_configfile=None):
             adagios_configfile = alternative_adagios_configfile
             open(adagios_configfile, "a").close()
 
-        execfile(adagios_configfile, globals())
+        exec(open(adagios_configfile).read(), globals())
         # if config has any default include, lets include that as well
         configfiles = glob(include)
         for configfile in configfiles:
-            execfile(configfile, globals())
+            exec(open(configfile).read(), globals())
     except IOError as e:
         warn('Unable to open %s: %s' % (adagios_configfile, e.strerror))
 
@@ -331,7 +330,6 @@ if not django_secret_key:
 else:
     SECRET_KEY = django_secret_key
 
-ALLOWED_INCLUDE_ROOTS = (serverside_includes,)
 
 if enable_status_view:
     #plugins['status'] = 'adagios.status'

--- a/adagios/status/forms.py
+++ b/adagios/status/forms.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import adagios.status.utils
 import adagios.businessprocess
 

--- a/adagios/status/rest.py
+++ b/adagios/status/rest.py
@@ -21,13 +21,7 @@ Convenient stateless functions for the status module. These are meant for progra
 with status of Nagios.
 
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from past.builtins import cmp
 from functools import cmp_to_key
-from builtins import str, int
-from past.utils import old_div
 import time
 import pynag.Control.Command
 import pynag.Model
@@ -36,7 +30,7 @@ import adagios.status.utils
 import pynag.Parsers
 import collections
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from adagios import userdata
 
 def hosts(request, fields=None, **kwargs):
@@ -552,7 +546,7 @@ def state_history(
         css_hint[2] = 'danger'
         css_hint[3] = 'info'
         for i in log:
-            i['duration_percent'] = old_div(100 * i['duration'], total_duration)
+            i['duration_percent'] = (100 * i['duration'] / total_duration)
             i['bootstrap_status'] = css_hint[i['state']]
 
     return log_entries

--- a/adagios/status/templatetags/adagiostags.py
+++ b/adagios/status/templatetags/adagiostags.py
@@ -19,7 +19,7 @@ import math
 from datetime import datetime, timedelta
 from django import template
 from django.utils.timesince import timesince
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 register = template.Library()
 

--- a/adagios/status/tests.py
+++ b/adagios/status/tests.py
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
 from django.test import TestCase
 from django.test.client import Client
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import pynag.Parsers
 import os

--- a/adagios/status/urls.py
+++ b/adagios/status/urls.py
@@ -1,63 +1,40 @@
-# Adagios is a web based Nagios configuration interface
-#
-# Copyright (C) 2014, Pall Sigurdsson <palli@opensource.is>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.urls import re_path
+import adagios.status.views
 
-from django.conf.urls import url, patterns
-
-urlpatterns = patterns('adagios',
-                        url(r'^/?$', 'status.views.status_index'),
-                        url(r'^/acknowledgements/?$', 'status.views.acknowledgement_list'),
-                        url(r'^/error/?$', 'status.views.error_page'),
-                        url(r'^/comments/?$', 'status.views.comment_list'),
-                        url(r'^/contacts/?$', 'status.views.contact_list'),
-                        url(r'^/contactgroups/?$', 'status.views.contactgroups'),
-                        url(r'^/dashboard/?$', 'status.views.dashboard'),
-                        url(r'^/detail/?$', 'status.views.detail'),
-                        url(r'^/downtimes/?$', 'status.views.downtime_list'),
-                        url(r'^/hostgroups/?$', 'status.views.status_hostgroups'),
-                        url(r'^/hosts/?$', 'status.views.hosts'),
-                        url(r'^/log/?$', 'status.views.log'),
-                        url(r'^/map/?', 'status.views.map_view'),
-                        url(r'^/parents/?$', 'status.views.network_parents'),
-                        url(r'^/perfdata/?$', 'status.views.perfdata'),
-                        url(r'^/perfdata2/?$', 'status.views.perfdata2'),
-                        url(r'^/problems/?$', 'status.views.problems'),
-                        url(r'^/servicegroups/?$', 'status.views.status_servicegroups'),
-                        url(r'^/services/?$', 'status.views.services'),
-                        url(r'^/state_history/?$', 'status.views.state_history'),
-                        url(r'^/backends/?$', 'status.views.backends'),
-
-
-
-                        # Misc snippets
-                        url(r'^/snippets/log/?$', 'status.views.snippets_log'),
-                        url(r'^/snippets/services/?$', 'status.views.snippets_services'),
-                        url(r'^/snippets/hosts/?$', 'status.views.snippets_hosts'),
-
-                        # Misc tests
-                        url(r'^/test/services/?$', 'status.views.services_js'),
-                        url(r'^/test/status_dt/?$', 'status.views.status_dt'),
-                        url(r'^/test/livestatus/?$', 'status.views.test_livestatus'),
-
-                        # Deprecated as of 2013-03-23
-                        url(r'^/contacts/(?P<contact_name>.+)/?$', 'status.views.contact_detail'),
-                        url(r'^/hostgroups/(?P<hostgroup_name>.+)/?$', 'status.views.status_hostgroup'),
-                        url(r'^/contactgroups/(?P<contactgroup_name>.+)/?$', 'status.views.contactgroup_detail'),
-                        url(r'^/servicegroups/(?P<servicegroup_name>.+)/?$', 'status.views.servicegroup_detail'),
-                        url(r'^/services_old/?$', 'status.views.status'),
-
-
-                        )
+urlpatterns = [
+    re_path(r'^/?$', adagios.status.views.status_index),
+    re_path(r'^/acknowledgements/?$', adagios.status.views.acknowledgement_list),
+    re_path(r'^/error/?$', adagios.status.views.error_page),
+    re_path(r'^/comments/?$', adagios.status.views.comment_list),
+    re_path(r'^/contacts/?$', adagios.status.views.contact_list),
+    re_path(r'^/contactgroups/?$', adagios.status.views.contactgroups),
+    re_path(r'^/dashboard/?$', adagios.status.views.dashboard),
+    re_path(r'^/detail/?$', adagios.status.views.detail),
+    re_path(r'^/downtimes/?$', adagios.status.views.downtime_list),
+    re_path(r'^/hostgroups/?$', adagios.status.views.status_hostgroups),
+    re_path(r'^/hosts/?$', adagios.status.views.hosts),
+    re_path(r'^/log/?$', adagios.status.views.log),
+    re_path(r'^/map/?', adagios.status.views.map_view),
+    re_path(r'^/parents/?$', adagios.status.views.network_parents),
+    re_path(r'^/perfdata/?$', adagios.status.views.perfdata),
+    re_path(r'^/perfdata2/?$', adagios.status.views.perfdata2),
+    re_path(r'^/problems/?$', adagios.status.views.problems),
+    re_path(r'^/servicegroups/?$', adagios.status.views.status_servicegroups),
+    re_path(r'^/services/?$', adagios.status.views.services),
+    re_path(r'^/state_history/?$', adagios.status.views.state_history),
+    re_path(r'^/backends/?$', adagios.status.views.backends),
+    # Snippets
+    re_path(r'^/snippets/log/?$', adagios.status.views.snippets_log),
+    re_path(r'^/snippets/services/?$', adagios.status.views.snippets_services),
+    re_path(r'^/snippets/hosts/?$', adagios.status.views.snippets_hosts),
+    # Tests
+    re_path(r'^/test/services/?$', adagios.status.views.services_js),
+    re_path(r'^/test/status_dt/?$', adagios.status.views.status_dt),
+    re_path(r'^/test/livestatus/?$', adagios.status.views.test_livestatus),
+    # Deprecated
+    re_path(r'^/contacts/(?P<contact_name>.+)/?$', adagios.status.views.contact_detail),
+    re_path(r'^/hostgroups/(?P<hostgroup_name>.+)/?$', adagios.status.views.status_hostgroup),
+    re_path(r'^/contactgroups/(?P<contactgroup_name>.+)/?$', adagios.status.views.contactgroup_detail),
+    re_path(r'^/servicegroups/(?P<servicegroup_name>.+)/?$', adagios.status.views.servicegroup_detail),
+    re_path(r'^/services_old/?$', adagios.status.views.status),
+]

--- a/adagios/status/utils.py
+++ b/adagios/status/utils.py
@@ -20,14 +20,8 @@
 # Utility functions for the status app. These are mostly used by
 # adagios.status.views
 
-from __future__ import division
-from __future__ import unicode_literals
-from future.utils import string_types
 from functools import cmp_to_key
-from past.builtins import cmp
-#from past.builtins import six.string_types
-from builtins import str
-from past.utils import old_div
+#from past.builtins import six.str
 import pynag.Utils
 import pynag.Parsers
 import adagios.settings
@@ -179,11 +173,11 @@ def add_statistics_to_hosts(result):
             try:
                 total = float(total)
                 host['health'] = float(ok) / total * 100.0
-                host['percent_ok'] = old_div(ok, total) * 100
-                host['percent_warn'] = old_div(warn, total) * 100
-                host['percent_crit'] = old_div(crit, total) * 100
-                host['percent_unknown'] = old_div(unknown, total) * 100
-                host['percent_pending'] = old_div(pending, total) * 100
+                host['percent_ok'] = (ok / total) * 100
+                host['percent_warn'] = (warn / total) * 100
+                host['percent_crit'] = (crit / total) * 100
+                host['percent_unknown'] = (unknown / total) * 100
+                host['percent_pending'] = (pending / total) * 100
             except ZeroDivisionError:
                 host['health'] = 'n/a'
         except Exception:
@@ -301,10 +295,10 @@ def get_hosts(request, fields=None, *args, **kwargs):
     if isinstance(fields, str):
         fields = fields.split(',')
 
-#    if isinstance(fields, string_types):
+#    if isinstance(fields, str):
 #        fields = fields.split(',')
 
-#    if isinstance(fields, six.string_types):
+#    if isinstance(fields, six.str):
 #        fields = fields.split(',')
 
     query.set_columns(*fields)
@@ -495,11 +489,11 @@ def get_statistics(request, *args, **kwargs):
 
     # Calculate percentage of hosts/services that are "ok"
     try:
-        c['service_totals_percent'] = [float(old_div(100.0 * x, c['total_services'])) for x in c['service_totals']]
+        c['service_totals_percent'] = [float((100.0 * x / c['total_services'])) for x in c['service_totals']]
     except ZeroDivisionError:
         c['service_totals_percent'] = [0, 0, 0, 0]
     try:
-        c['host_totals_percent'] = [float(old_div(100.0 * x, c['total_hosts'])) for x in c['host_totals']]
+        c['host_totals_percent'] = [float((100.0 * x / c['total_hosts'])) for x in c['host_totals']]
     except ZeroDivisionError:
         c['host_totals_percent'] = [0, 0, 0, 0]
     

--- a/adagios/status/views.py
+++ b/adagios/status/views.py
@@ -17,14 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from past.builtins import cmp
-from future.utils import string_types
-from builtins import str
-from builtins import map
-from past.utils import old_div
 from django.http import HttpResponse
 from functools import cmp_to_key
 
@@ -34,11 +26,10 @@ from collections import defaultdict
 import json
 import traceback
 
-from django.shortcuts import render_to_response, redirect
-from django.template import RequestContext
+from django.shortcuts import render, redirect, redirect
 from django.utils.encoding import smart_str
-from django.core.context_processors import csrf
-from django.utils.translation import ugettext as _
+# csrf is handled automatically by Django middleware
+from django.utils.translation import gettext as _
 
 import pynag.Model
 import pynag.Utils
@@ -52,7 +43,7 @@ from adagios.status import utils
 import adagios.status.rest
 import adagios.status.forms
 import adagios.businessprocess
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from adagios.status import graphite
 
 state = defaultdict(lambda: "unknown")
@@ -121,17 +112,17 @@ def network_parents(request):
                     crit += 1
             total = float(len(i['childs']))
             i['health'] = float(ok) / total * 100.0
-            i['percent_ok'] = old_div(ok, total) * 100
-            i['percent_crit'] = old_div(crit, total) * 100
+            i['percent_ok'] = (ok / total) * 100
+            i['percent_crit'] = (crit / total) * 100
 
-    return render_to_response('status_parents.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_parents.html', c)
 
 
 @adagios_decorator
 def status(request):
     """ Compatibility layer around status.views.services
     """
-    # return render_to_response('status.html', c, context_instance=RequestContext(request))
+    # return render(request, 'status.html', c)
     # Left here for compatibility reasons:
     return services(request)
 
@@ -146,7 +137,7 @@ def services(request):
         'host_name', 'description', 'plugin_output', 'last_check', 'host_state', 'state',
         'last_state_change', 'acknowledged', 'downtimes', 'host_downtimes', 'comments_with_info']
     c['services'] = utils.get_services(request, fields=fields, **request.GET)
-    return render_to_response('status_services.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_services.html', c)
 
 @adagios_decorator
 def services_js(request):
@@ -158,14 +149,14 @@ def services_js(request):
         'host_name', 'description', 'plugin_output', 'last_check', 'host_state', 'state',
         'last_state_change', 'acknowledged', 'downtimes', 'host_downtimes', 'comments_with_info']
     c['services'] = json.dumps(utils.get_services(request, fields=fields, **request.GET))
-    return render_to_response('status_services_js.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_services_js.html', c)
 
 
 @adagios_decorator
 def status_dt(request):
     """ This view handles list of services  """
     c = {}
-    return render_to_response('status_dt.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_dt.html', c)
 
 
 @adagios_decorator
@@ -178,7 +169,7 @@ def snippets_services(request):
         'host_name', 'description', 'plugin_output', 'last_check', 'host_state', 'state',
         'last_state_change', 'acknowledged', 'downtimes', 'host_downtimes', 'comments_with_info']
     c['services'] = utils.get_services(request, fields=fields, **request.GET)
-    return render_to_response('snippets/status_servicelist_snippet.html', c, context_instance=RequestContext(request))
+    return render(request, 'snippets/status_servicelist_snippet.html', c)
 
 @adagios_decorator
 def snippets_hosts(request):
@@ -187,7 +178,7 @@ def snippets_hosts(request):
     c['errors'] = []
     c['hosts'] = utils.get_hosts(request, **request.GET)
     c['host_name'] = request.GET.get('detail', None)
-    return render_to_response('snippets/status_hostlist_snippet.html', c, context_instance=RequestContext(request))
+    return render(request, 'snippets/status_hostlist_snippet.html', c)
 
 
 @adagios_decorator
@@ -236,10 +227,10 @@ def snippets_log(request):
         css_hint[2] = 'danger'
         css_hint[3] = 'unknown'
         for i in log:
-            i['duration_percent'] = old_div(100 * i['duration'], total_duration)
+            i['duration_percent'] = (100 * i['duration'] / total_duration)
             i['bootstrap_status'] = css_hint[i['state']]
 
-    return render_to_response('snippets/status_statehistory_snippet.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'snippets/status_statehistory_snippet.html', locals())
 
 
 @adagios_decorator
@@ -352,7 +343,7 @@ def service_detail(request, host_name, service_description):
                     default[k] = v
                 c['graphite_default'] = default
     
-    return render_to_response('status_detail.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_detail.html', c)
 
 
 def _get_network_parents(request, host_name):
@@ -419,7 +410,7 @@ def hostgroup_detail(request, hostgroup_name):
         _add_statistics_to_hostgroups(c['hostgroups'])
     except Exception as e:
         c['errors'].append(e)
-    return render_to_response('status_hostgroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_hostgroup.html', c)
 
 
 def _add_statistics_to_hostgroups(hostgroups):
@@ -453,11 +444,11 @@ def _add_statistics_to_hostgroups(hostgroups):
             total = float(total)
             hg['health'] = float(ok) / total * 100.0
             hg['health'] = float(ok) / total * 100.0
-            hg['percent_ok'] = old_div(ok, total) * 100
-            hg['percent_warn'] = old_div(warn, total) * 100
-            hg['percent_crit'] = old_div(crit, total) * 100
-            hg['percent_unknown'] = old_div(unknown, total) * 100
-            hg['percent_pending'] = old_div(pending, total) * 100
+            hg['percent_ok'] = (ok / total) * 100
+            hg['percent_warn'] = (warn / total) * 100
+            hg['percent_crit'] = (crit / total) * 100
+            hg['percent_unknown'] = (unknown / total) * 100
+            hg['percent_pending'] = (pending / total) * 100
         except ZeroDivisionError:
             pass
 
@@ -473,7 +464,7 @@ def status_servicegroups(request):
     c['servicegroup_name'] = servicegroup_name
     c['request'] = request
     c['servicegroups'] = servicegroups
-    return render_to_response('status_servicegroups.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_servicegroups.html', c)
 
 
 @adagios_decorator
@@ -538,11 +529,11 @@ def status_hostgroups(request):
         try:
             total = float(total)
             host['health'] = float(ok) / total * 100.0
-            host['percent_ok'] = old_div(ok, total) * 100
-            host['percent_warn'] = old_div(warn, total) * 100
-            host['percent_crit'] = old_div(crit, total) * 100
-            host['percent_unknown'] = old_div(unknown, total) * 100
-            host['percent_pending'] = old_div(pending, total) * 100
+            host['percent_ok'] = (ok / total) * 100
+            host['percent_warn'] = (warn / total) * 100
+            host['percent_crit'] = (crit / total) * 100
+            host['percent_unknown'] = (unknown / total) * 100
+            host['percent_pending'] = (pending / total) * 100
         except ZeroDivisionError:
             host['health'] = 'n/a'
     # Extra statistics for our hostgroups
@@ -559,14 +550,14 @@ def status_hostgroups(request):
             total = float(total)
             hg['health'] = float(ok) / total * 100.0
             hg['health'] = float(ok) / total * 100.0
-            hg['percent_ok'] = old_div(ok, total) * 100
-            hg['percent_warn'] = old_div(warn, total) * 100
-            hg['percent_crit'] = old_div(crit, total) * 100
-            hg['percent_unknown'] = old_div(unknown, total) * 100
-            hg['percent_pending'] = old_div(pending, total) * 100
+            hg['percent_ok'] = (ok / total) * 100
+            hg['percent_warn'] = (warn / total) * 100
+            hg['percent_crit'] = (crit / total) * 100
+            hg['percent_unknown'] = (unknown / total) * 100
+            hg['percent_pending'] = (pending / total) * 100
         except ZeroDivisionError:
             pass
-    return render_to_response('status_hostgroups.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_hostgroups.html', c)
 
 
 @adagios_decorator
@@ -582,7 +573,7 @@ def hosts(request):
     c['errors'] = []
     c['hosts'] = utils.get_hosts(request, **request.GET)
     c['host_name'] = request.GET.get('detail', None)
-    return render_to_response('status_host.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_host.html', c)
 
 
 @adagios_decorator
@@ -595,7 +586,7 @@ def problems(request):
         search_filter['state__isnot'] = '0'
     c['hosts'] = utils.get_hosts(request, **search_filter)
     c['services'] = utils.get_services(request, **search_filter)
-    return render_to_response('status_problems.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_problems.html', c)
 
 
 
@@ -639,11 +630,11 @@ def _add_statistics_to_hosts(hosts):
         try:
             total = float(total)
             host['health'] = float(ok) / total * 100.0
-            host['percent_ok'] = old_div(ok, total) * 100
-            host['percent_warn'] = old_div(warn, total) * 100
-            host['percent_crit'] = old_div(crit, total) * 100
-            host['percent_unknown'] = old_div(unknown, total) * 100
-            host['percent_pending'] = old_div(pending, total) * 100
+            host['percent_ok'] = (ok / total) * 100
+            host['percent_warn'] = (warn / total) * 100
+            host['percent_crit'] = (crit / total) * 100
+            host['percent_unknown'] = (unknown / total) * 100
+            host['percent_pending'] = (pending / total) * 100
         except ZeroDivisionError:
             host['health'] = 'n/a'
             host['percent_ok'] = 0
@@ -657,7 +648,7 @@ def _add_statistics_to_hosts(hosts):
 def status_index(request):
     c = adagios.status.utils.get_statistics(request)
     c['services'] = adagios.status.utils.get_services(request, unhandled=True)
-    return render_to_response('status_index.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_index.html', c)
 
 
 @adagios_decorator
@@ -691,7 +682,7 @@ def test_livestatus(request):
             c['query'] = livestatus.last_query
             c['header'] = list(c['results'][0].keys())
 
-    return render_to_response('test_livestatus.html', c, context_instance=RequestContext(request))
+    return render(request, 'test_livestatus.html', c)
 
 
 def _status_combined(request, optimized=False):
@@ -751,11 +742,11 @@ def _status_combined(request, optimized=False):
     if service_totals == 0:
         c['service_status'] = 0
     else:
-        c['service_status'] = [old_div(100 * x, service_totals) for x in service_status]
+        c['service_status'] = [(100 * x / service_totals) for x in service_status]
     if host_totals == 0:
         c['host_status'] = 0
     else:
-        c['host_status'] = [old_div(100 * x, host_totals) for x in host_status]
+        c['host_status'] = [(100 * x / host_totals) for x in host_status]
     return c
 
 
@@ -783,7 +774,7 @@ def dashboard(request):
         reverse=True, key=cmp_to_key(lambda a, b: cmp(a['last_check'], b['last_check'])))
     c['service_problems'].sort(
         reverse=True, key=cmp_to_key(lambda a, b: cmp(a['state'], b['state'])))
-    return render_to_response('status_dashboard.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_dashboard.html', c)
 
 
 @adagios_decorator
@@ -865,7 +856,7 @@ def state_history(request):
             last_item['end_time'] = end_time
             last_item['duration'] = duration = last_item[
                 'end_time'] - last_item['time']
-            last_item['duration_percent'] = old_div(100 * duration, total_duration)
+            last_item['duration_percent'] = (100 * duration / total_duration)
             service['duration'] += last_item['duration_percent']
             if last_item['state'] == 0:
                 service['sla'] += last_item['duration_percent']
@@ -886,7 +877,7 @@ def state_history(request):
     c['services'] = services
     c['start_time'] = start_time
     c['end_time'] = end_time
-    return render_to_response('state_history.html', c, context_instance=RequestContext(request))
+    return render(request, 'state_history.html', c)
 
 
 def _status_log(request):
@@ -952,7 +943,7 @@ def log(request):
     c = _status_log(request)
     c['request'] = request
     c['log'].reverse()
-    return render_to_response('status_log.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_log.html', c)
 
 
 @adagios_decorator
@@ -964,7 +955,7 @@ def comment_list(request):
     l = adagios.status.utils.livestatus(request)
     args = pynag.Utils.grep_to_livestatus(**request.GET)
     c['comments'] = l.query('GET comments', *args)
-    return render_to_response('status_comments.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_comments.html', c)
 
 
 @adagios_decorator
@@ -976,7 +967,7 @@ def downtime_list(request):
     l = adagios.status.utils.livestatus(request)
     args = pynag.Utils.grep_to_livestatus(**request.GET)
     c['downtimes'] = l.query('GET downtimes', *args)
-    return render_to_response('status_downtimes.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_downtimes.html', c)
 
 @adagios_decorator
 def acknowledgement_list(request):
@@ -987,7 +978,7 @@ def acknowledgement_list(request):
     l = adagios.status.utils.livestatus(request)
     args = pynag.Utils.grep_to_livestatus(**request.GET)
     c['acknowledgements'] = l.query('GET comments', 'Filter: entry_type = 4', *args)
-    return render_to_response('status_acknowledgements.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_acknowledgements.html', c)
 
 
 @adagios_decorator
@@ -1005,7 +996,7 @@ def perfdata(request):
         i['metrics'] = metrics
 
     c['perfdata'] = perfdata
-    return render_to_response('status_perfdata.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_perfdata.html', c)
 
 
 @adagios_decorator
@@ -1016,7 +1007,7 @@ def contact_list(request):
     c['messages'] = []
     c['errors'] = []
     c['contacts'] = adagios.status.utils.get_contacts(request, **request.GET)
-    return render_to_response('status_contacts.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_contacts.html', c)
 
 
 @adagios_decorator
@@ -1061,7 +1052,7 @@ def contact_detail(request, contact_name):
     nagiosdir = dirname(adagios.settings.nagios_config or pynag.Model.config.guess_cfg_file())
     git = pynag.Utils.GitRepo(directory=nagiosdir)
     c['gitlog'] = git.log(author_name=contact_name.decode('utf-8'))
-    return render_to_response('status_contact.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_contact.html', c)
 
 
 @adagios_decorator
@@ -1072,7 +1063,7 @@ def map_view(request):
     c['map_center'] = adagios.settings.map_center
     c['map_zoom'] = adagios.settings.map_zoom
 
-    return render_to_response('status_map.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_map.html', c)
 
 
 @adagios_decorator
@@ -1087,7 +1078,7 @@ def servicegroup_detail(request, servicegroup_name):
     search_conditions.pop('servicegroup_name')
 
     c['services'] = adagios.status.utils.get_services(request, groups__has_field=servicegroup_name, **search_conditions)
-    return render_to_response('status_servicegroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_servicegroup.html', c)
 
 @adagios_decorator
 def contactgroups(request):
@@ -1098,7 +1089,7 @@ def contactgroups(request):
     c['errors'] = []
     l = adagios.status.utils.livestatus(request)
     c['contactgroups'] = l.get_contactgroups(**request.GET)
-    return render_to_response('status_contactgroups.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_contactgroups.html', c)
 
 
 @adagios_decorator
@@ -1136,7 +1127,7 @@ def contactgroup_detail(request, contactgroup_name):
         contacts.append(contact)
     c['contacts'] = contacts
 
-    return render_to_response('status_contactgroup.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_contactgroup.html', c)
 
 
 
@@ -1185,7 +1176,7 @@ def perfdata2(request):
     c['metrics'] = interesting_metrics
     c['services'] = services
 
-    return render_to_response('status_perfdata2.html', c, context_instance=RequestContext(request))
+    return render(request, 'status_perfdata2.html', c)
 
 
 def acknowledge(request):
@@ -1222,4 +1213,4 @@ def backends(request):
     backends = livestatus.get_backends()
     for i, v in list(backends.items()):
         v.test(raise_error=False)
-    return render_to_response('status_backends.html', locals(), context_instance=RequestContext(request))
+    return render(request, 'status_backends.html', locals())

--- a/adagios/urls.py
+++ b/adagios/urls.py
@@ -6,53 +6,37 @@
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns, include
+from django.urls import re_path, include
 from adagios import settings
 from django.views.static import serve
+import adagios.views
+import django.views.i18n
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-# admin.autodiscover()
-
-urlpatterns = patterns(
-    '',
-    # Example:
-    url(r'^$', 'adagios.views.index', name="home"),
-    url(r'^403', 'adagios.views.http_403'),
-    url(r'^objectbrowser', include('adagios.objectbrowser.urls')),
-    url(r'^status', include('adagios.status.urls')),
-    url(r'^bi', include('adagios.bi.urls')),
-    url(r'^misc', include('adagios.misc.urls')),
-    url(r'^pnp', include('adagios.pnp.urls')),
-    url(r'^media(?P<path>.*)$',         serve, {'document_root': settings.STATIC_ROOT }),
-    url(r'^rest', include('adagios.rest.urls')),
-    url(r'^contrib', include('adagios.contrib.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
-    # (r'^admin/', include(admin.site.urls)),
-
+urlpatterns = [
+    re_path(r'^$', adagios.views.index, name="home"),
+    re_path(r'^403', adagios.views.http_403),
+    re_path(r'^objectbrowser', include('adagios.objectbrowser.urls')),
+    re_path(r'^status', include('adagios.status.urls')),
+    re_path(r'^bi', include('adagios.bi.urls')),
+    re_path(r'^misc', include('adagios.misc.urls')),
+    re_path(r'^pnp', include('adagios.pnp.urls')),
+    re_path(r'^media(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
+    re_path(r'^rest', include('adagios.rest.urls')),
+    re_path(r'^contrib', include('adagios.contrib.urls')),
     # Internationalization
-    url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog'),
-)
+    re_path(r'^jsi18n/$', django.views.i18n.JavaScriptCatalog.as_view()),
+]
 
 if settings.DEBUG:
-    urlpatterns += patterns('',
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.STATIC_ROOT}, name="media"),
-    )
-        
-
-# from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-#urlpatterns += staticfiles_urlpatterns()
-
+    urlpatterns += [
+        re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}, name="media"),
+    ]

--- a/adagios/userdata.py
+++ b/adagios/userdata.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from builtins import object
 import os
 import json
 import collections

--- a/adagios/utils.py
+++ b/adagios/utils.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from builtins import object
 import adagios.status.utils
 import adagios
 import pynag.Model
@@ -27,7 +25,7 @@ import adagios.settings
 import os
 import pynag.Utils.misc
 from multiprocessing.pool import ThreadPool
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 SELENIUM_DRIVER = None
 

--- a/adagios/views.py
+++ b/adagios/views.py
@@ -15,13 +15,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from builtins import str
 from django.http import HttpResponse
 import traceback
-from django.shortcuts import render_to_response, redirect
-from django.template import RequestContext, loader
+from django.shortcuts import render, redirect, redirect
 from django import template
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import time
 import logging
 import adagios.settings
@@ -67,7 +65,7 @@ def error_page(request, context=None):
         content = str(context)
         response = HttpResponse(content=content, content_type='application/json')
     else:
-        response = render_to_response('status_error.html', context, context_instance=RequestContext(request))
+        response = render(request, 'status_error.html', context)
     response.status_code = 500
     return response
 
@@ -91,6 +89,6 @@ def http_403(request, exception=None):
         c['access_required'] = exception.access_required
         response = HttpResponse(content=str(c), content_type='application/json')
     else:
-        response = render_to_response('403.html', context, context_instance=RequestContext(request))
+        response = render(request, '403.html', context)
     response.status_code = 403
     return response


### PR DESCRIPTION
- Replace execfile() with exec(open().read()) in settings.py
- Migrate MIDDLEWARE_CLASSES to MIDDLEWARE list
- Replace TEMPLATE_* settings with TEMPLATES dict
- Update context processors to django.template.context_processors.*
- Replace patterns()/url() with re_path() across all urls.py files
- Convert string-based view references to direct callable imports
- Update JavaScriptCatalog to class-based as_view()
- Replace render_to_response/RequestContext with render()
- Migrate django.core.urlresolvers to django.urls
- Replace ugettext with gettext (removed in Django 4.0)
- Update AuthorizationMiddleWare to new-style middleware API
- Remove future/past/builtins compatibility imports
- Replace string_types with str and old_div with / operator
- Remove deprecated ALLOWED_INCLUDE_ROOTS setting"